### PR TITLE
fixes problems with nan called in masks addressing issue 62

### DIFF
--- a/acro/acro.py
+++ b/acro/acro.py
@@ -279,7 +279,7 @@ class ACRO:
             mask.replace({0:False,1:True},inplace=True)
             masks[name]=mask
 
-        
+
         table, outcome = utils.apply_suppression(table, masks)
         summary = utils.get_summary(masks)
         self.__add_output(command, summary, outcome, [table])

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -272,7 +272,14 @@ class ACRO:
                 masks["missing"] = pd.crosstab(
                     index, columns, values, aggfunc=utils.agg_missing
                 )
+        #pd.crosstab returns nan for an empty cell
+        for name,mask in masks.items():
+            mask.fillna(value=1,inplace=True)
+            mask = mask.astype(int)
+            mask.replace({0:False,1:True},inplace=True)
+            masks[name]=mask
 
+        
         table, outcome = utils.apply_suppression(table, masks)
         summary = utils.get_summary(masks)
         self.__add_output(command, summary, outcome, [table])

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -272,14 +272,13 @@ class ACRO:
                 masks["missing"] = pd.crosstab(
                     index, columns, values, aggfunc=utils.agg_missing
                 )
-        #pd.crosstab returns nan for an empty cell
-        for name,mask in masks.items():
-            mask.fillna(value=1,inplace=True)
+        # pd.crosstab returns nan for an empty cell
+        for name, mask in masks.items():
+            mask.fillna(value=1, inplace=True)
             mask = mask.astype(int)
-            mask.replace({0:False,1:True},inplace=True)
-            masks[name]=mask
+            mask.replace({0: False, 1: True}, inplace=True)
+            masks[name] = mask
 
-        
         table, outcome = utils.apply_suppression(table, masks)
         summary = utils.get_summary(masks)
         self.__add_output(command, summary, outcome, [table])

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -311,7 +311,7 @@ def apply_suppression(
                 tmp_df[mask.values] = name + "; "
                 outcome_df += tmp_df
             except TypeError:
-                logger.warning(f"problem mask %s is not binary", name)
+                logger.warning("problem mask %s is not binary", name)
         outcome_df = outcome_df.replace({"": "ok"})
     logger.info("outcome_df:\n%s", outcome_df)
     return safe_df, outcome_df

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -311,7 +311,7 @@ def apply_suppression(
                 tmp_df[mask.values] = name + "; "
                 outcome_df += tmp_df
             except TypeError:
-                logger.warning(f"problem mask %s is not binary",name)
+                logger.warning("problem mask %s is not binary",name)
         outcome_df = outcome_df.replace({"": "ok"})
     logger.info("outcome_df:\n%s", outcome_df)
     return safe_df, outcome_df

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -304,11 +304,14 @@ def apply_suppression(
     # apply suppression masks
     else:
         for name, mask in masks.items():
-            safe_df[mask.values] = np.NaN
-            tmp_df = DataFrame().reindex_like(outcome_df)
-            tmp_df.fillna("", inplace=True)
-            tmp_df[mask.values] = name + "; "
-            outcome_df += tmp_df
+            try:
+                safe_df[mask.values] = np.NaN
+                tmp_df = DataFrame().reindex_like(outcome_df)
+                tmp_df.fillna("", inplace=True)
+                tmp_df[mask.values] = name + "; "
+                outcome_df += tmp_df
+            except TypeError:
+                logger.warning(f"problem for {name} with mask \n{mask.values}")
         outcome_df = outcome_df.replace({"": "ok"})
     logger.info("outcome_df:\n%s", outcome_df)
     return safe_df, outcome_df

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -311,7 +311,7 @@ def apply_suppression(
                 tmp_df[mask.values] = name + "; "
                 outcome_df += tmp_df
             except TypeError:
-                logger.warning(f"problem mask %s is not binary",name)
+                logger.warning(f"problem mask %s is not binary", name)
         outcome_df = outcome_df.replace({"": "ok"})
     logger.info("outcome_df:\n%s", outcome_df)
     return safe_df, outcome_df

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -311,7 +311,7 @@ def apply_suppression(
                 tmp_df[mask.values] = name + "; "
                 outcome_df += tmp_df
             except TypeError:
-                logger.warning(f"problem for {name} with mask \n{mask.values}")
+                logger.warning(f"problem mask %s is not binary",name)
         outcome_df = outcome_df.replace({"": "ok"})
     logger.info("outcome_df:\n%s", outcome_df)
     return safe_df, outcome_df

--- a/notebooks/test-nursery.ipynb
+++ b/notebooks/test-nursery.ipynb
@@ -1,0 +1,963 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "00cac1f9",
+   "metadata": {},
+   "source": [
+    "# ACRO Tests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e33fd4fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import pandas as pd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c01cfe12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sys.path.insert(0, os.path.abspath(\"..\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cc8d993a",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from acro import ACRO, add_constant, utils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "530efcfe",
+   "metadata": {},
+   "source": [
+    "### Instantiate ACRO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4b8a77e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False}\n"
+     ]
+    }
+   ],
+   "source": [
+    "acro = ACRO()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27a2baaa",
+   "metadata": {},
+   "source": [
+    "### Load test data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ac790b2b-b02f-49f7-8237-a033abed6e87",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       parents has_nurs      form children     housing     finance   social  \\\n",
+      "count    12960    12960     12960    12960       12960       12960    12960   \n",
+      "unique       3        5         4        4           3           2        3   \n",
+      "top      usual   proper  complete        1  convenient  convenient  nonprob   \n",
+      "freq      4320     2592      3240     3240        4320        6480     4320   \n",
+      "\n",
+      "             health  recommend  \n",
+      "count         12960      12960  \n",
+      "unique            3          5  \n",
+      "top     recommended  not_recom  \n",
+      "freq           4320       4320  \n"
+     ]
+    }
+   ],
+   "source": [
+    "#path = os.path.join(\"../data\", \"test_data.dta\")\n",
+    "#df = pd.read_stata(path)\n",
+    "#df.head()\n",
+    "from sklearn.datasets import fetch_openml\n",
+    "data =  fetch_openml(data_id=26, as_frame=True)\n",
+    "df = data.data\n",
+    "df['recommend'] = data.target\n",
+    "print(df.describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea2a0d76-ba68-4a74-93c3-bdaa88c48929",
+   "metadata": {},
+   "source": [
+    "### convert 'more than 3' children to random between 4 and 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7fb14245-e465-48a4-a5d6-88508d5bb08f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['1', '2', '3', 'more']\n",
+      "Categories (4, object): ['1', '2', '3', 'more']\n",
+      "values before apply transforamtion: [1 2 3 4]\n",
+      "values after apply transformation: [1 2 3 9 5 8 7 4 6]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>children</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>12960.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>3.124306</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>2.243437</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>1.750000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>2.500000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>3.250000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>9.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           children\n",
+       "count  12960.000000\n",
+       "mean       3.124306\n",
+       "std        2.243437\n",
+       "min        1.000000\n",
+       "25%        1.750000\n",
+       "50%        2.500000\n",
+       "75%        3.250000\n",
+       "max        9.000000"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(df['children'].unique())\n",
+    "df['children'].replace( to_replace={'more':'4'}, inplace=True)\n",
+    "df['children'] = pd.to_numeric(df['children'])\n",
+    "print(f\"values before apply transforamtion: {df['children'].unique()}\")\n",
+    "      \n",
+    "df['children'] = df.apply(lambda row: row['children'] if row['children'] in (1,2,3) else np.random.randint(4,10), axis=1)\n",
+    "print(f\"values after apply transformation: {df['children'].unique()}\")\n",
+    "\n",
+    "df.describe()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ae844a0",
+   "metadata": {},
+   "source": [
+    "### Pandas crosstab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "961684cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>parents</th>\n",
+       "      <th>usual</th>\n",
+       "      <th>pretentious</th>\n",
+       "      <th>great_pret</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>recommend</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>not_recom</th>\n",
+       "      <td>1440</td>\n",
+       "      <td>1440</td>\n",
+       "      <td>1440</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>recommend</th>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>very_recom</th>\n",
+       "      <td>196</td>\n",
+       "      <td>132</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>priority</th>\n",
+       "      <td>1924</td>\n",
+       "      <td>1484</td>\n",
+       "      <td>858</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>spec_prior</th>\n",
+       "      <td>758</td>\n",
+       "      <td>1264</td>\n",
+       "      <td>2022</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "parents     usual  pretentious  great_pret\n",
+       "recommend                                 \n",
+       "not_recom    1440         1440        1440\n",
+       "recommend       2            0           0\n",
+       "very_recom    196          132           0\n",
+       "priority     1924         1484         858\n",
+       "spec_prior    758         1264        2022"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "table = pd.crosstab(df.recommend, df.parents)\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d642ed00",
+   "metadata": {},
+   "source": [
+    "### ACRO crosstab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bb4b2677",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:acro:outcome_df:\n",
+      "parents           usual  pretentious   great_pret\n",
+      "recommend                                        \n",
+      "not_recom            ok           ok           ok\n",
+      "recommend   threshold;   threshold;   threshold; \n",
+      "very_recom           ok           ok  threshold; \n",
+      "priority             ok           ok           ok\n",
+      "spec_prior           ok           ok           ok\n",
+      "INFO:acro:get_summary(): fail; threshold: 4 cells suppressed; \n",
+      "INFO:acro:add_output(): output_0_2023-04-26-21301610\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>parents</th>\n",
+       "      <th>usual</th>\n",
+       "      <th>pretentious</th>\n",
+       "      <th>great_pret</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>recommend</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>not_recom</th>\n",
+       "      <td>1440.0</td>\n",
+       "      <td>1440.0</td>\n",
+       "      <td>1440.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>recommend</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>very_recom</th>\n",
+       "      <td>196.0</td>\n",
+       "      <td>132.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>priority</th>\n",
+       "      <td>1924.0</td>\n",
+       "      <td>1484.0</td>\n",
+       "      <td>858.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>spec_prior</th>\n",
+       "      <td>758.0</td>\n",
+       "      <td>1264.0</td>\n",
+       "      <td>2022.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "parents      usual  pretentious  great_pret\n",
+       "recommend                                  \n",
+       "not_recom   1440.0       1440.0      1440.0\n",
+       "recommend      NaN          NaN         NaN\n",
+       "very_recom   196.0        132.0         NaN\n",
+       "priority    1924.0       1484.0       858.0\n",
+       "spec_prior   758.0       1264.0      2022.0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "safe_table = acro.crosstab(df.recommend, df.parents)\n",
+    "safe_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b603548",
+   "metadata": {},
+   "source": [
+    "### ACRO crosstab with aggregation function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "298d2b40",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:acro:outcome_df:\n",
+      "parents                             usual                    pretentious  \\\n",
+      "recommend                                                                  \n",
+      "not_recom                              ok                             ok   \n",
+      "recommend   threshold; p-ratio; nk-rule;   threshold; p-ratio; nk-rule;    \n",
+      "very_recom                             ok                             ok   \n",
+      "priority                               ok                             ok   \n",
+      "spec_prior                             ok                             ok   \n",
+      "\n",
+      "parents                        great_pret  \n",
+      "recommend                                  \n",
+      "not_recom                              ok  \n",
+      "recommend   threshold; p-ratio; nk-rule;   \n",
+      "very_recom  threshold; p-ratio; nk-rule;   \n",
+      "priority                               ok  \n",
+      "spec_prior                             ok  \n",
+      "INFO:acro:get_summary(): fail; threshold: 4 cells suppressed; p-ratio: 4 cells suppressed; nk-rule: 4 cells suppressed; \n",
+      "INFO:acro:add_output(): output_1_2023-04-26-21301622\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>parents</th>\n",
+       "      <th>usual</th>\n",
+       "      <th>pretentious</th>\n",
+       "      <th>great_pret</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>recommend</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>not_recom</th>\n",
+       "      <td>3.128472</td>\n",
+       "      <td>3.119444</td>\n",
+       "      <td>3.075694</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>recommend</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>very_recom</th>\n",
+       "      <td>2.260204</td>\n",
+       "      <td>2.166667</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>priority</th>\n",
+       "      <td>3.136694</td>\n",
+       "      <td>3.030997</td>\n",
+       "      <td>2.611888</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>spec_prior</th>\n",
+       "      <td>3.377309</td>\n",
+       "      <td>3.321203</td>\n",
+       "      <td>3.363996</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "parents        usual  pretentious  great_pret\n",
+       "recommend                                    \n",
+       "not_recom   3.128472     3.119444    3.075694\n",
+       "recommend        NaN          NaN         NaN\n",
+       "very_recom  2.260204     2.166667         NaN\n",
+       "priority    3.136694     3.030997    2.611888\n",
+       "spec_prior  3.377309     3.321203    3.363996"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "safe_table = acro.crosstab(df.recommend, df.parents, values=df.children, aggfunc=\"mean\")\n",
+    "safe_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a521cb83",
+   "metadata": {},
+   "source": [
+    "### ACRO crosstab with missing values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf132239",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "utils.CHECK_MISSING_VALUES = True\n",
+    "\n",
+    "missing = df.children()\n",
+    "missing[0:10] = np.NaN\n",
+    "\n",
+    "safe_table = acro.crosstab(df.year, df.grant_type, values=missing, aggfunc=\"mean\")\n",
+    "safe_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cc417a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "utils.CHECK_MISSING_VALUES = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcc81e98",
+   "metadata": {},
+   "source": [
+    "### ACRO crosstab with negative values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15bcdc7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "negative = df.inc_grants.copy()\n",
+    "negative[0:10] = -10\n",
+    "\n",
+    "safe_table = acro.crosstab(df.year, df.grant_type, values=negative, aggfunc=\"mean\")\n",
+    "safe_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d66e565b",
+   "metadata": {},
+   "source": [
+    "### ACRO pivot_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "966c1a9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = acro.pivot_table(\n",
+    "    df, index=[\"grant_type\"], values=[\"inc_grants\"], aggfunc=[\"mean\", \"std\"]\n",
+    ")\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc99fa71",
+   "metadata": {},
+   "source": [
+    "### ACRO pivot_table with missing values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3a87c20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "utils.CHECK_MISSING_VALUES = True\n",
+    "\n",
+    "df.loc[0:10, \"inc_grants\"] = np.NaN\n",
+    "\n",
+    "table = acro.pivot_table(\n",
+    "    df, index=[\"grant_type\"], values=[\"inc_grants\"], aggfunc=[\"mean\", \"std\"]\n",
+    ")\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac4fd993",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "utils.CHECK_MISSING_VALUES = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1f77749",
+   "metadata": {},
+   "source": [
+    "### ACRO pivot_table with negative values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01152d49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.loc[0:10, \"inc_grants\"] = -10\n",
+    "\n",
+    "table = acro.pivot_table(\n",
+    "    df, index=[\"grant_type\"], values=[\"inc_grants\"], aggfunc=[\"mean\", \"std\"]\n",
+    ")\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45ec04ef",
+   "metadata": {},
+   "source": [
+    "### ACRO OLS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f462e42",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "new_df = df[[\"inc_activity\", \"inc_grants\", \"inc_donations\", \"total_costs\"]]\n",
+    "new_df = new_df.dropna()\n",
+    "\n",
+    "y = new_df[\"inc_activity\"]\n",
+    "x = new_df[[\"inc_grants\", \"inc_donations\", \"total_costs\"]]\n",
+    "x = add_constant(x)\n",
+    "\n",
+    "results = acro.ols(y, x)\n",
+    "results.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c826271",
+   "metadata": {},
+   "source": [
+    "### ACRO OLSR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc90f7c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = acro.olsr(\n",
+    "    formula=\"inc_activity ~ inc_grants + inc_donations + total_costs\", data=new_df\n",
+    ")\n",
+    "results.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2816eac7",
+   "metadata": {},
+   "source": [
+    "### ACRO Probit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b1a1611",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_df = df[[\"survivor\", \"inc_activity\", \"inc_grants\", \"inc_donations\", \"total_costs\"]]\n",
+    "new_df = new_df.dropna()\n",
+    "\n",
+    "y = new_df[\"survivor\"].astype(\"category\").cat.codes  # numeric\n",
+    "y.name = \"survivor\"\n",
+    "x = new_df[[\"inc_activity\", \"inc_grants\", \"inc_donations\", \"total_costs\"]]\n",
+    "x = add_constant(x)\n",
+    "\n",
+    "results = acro.probit(y, x)\n",
+    "results.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f38b4334",
+   "metadata": {},
+   "source": [
+    "### ACRO Logit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcf30f8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = acro.logit(y, x)\n",
+    "results.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e554eea",
+   "metadata": {},
+   "source": [
+    "### List current ACRO outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec960039",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "acro.print_outputs()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f78b5a08",
+   "metadata": {},
+   "source": [
+    "### Remove some ACRO outputs before finalising"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4ee985e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_1 = list(acro.results.keys())[1]\n",
+    "output_4 = list(acro.results.keys())[4]\n",
+    "\n",
+    "acro.remove_output(output_1)\n",
+    "acro.remove_output(output_4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df2a02e0",
+   "metadata": {},
+   "source": [
+    "### Rename ACRO outputs before finalising"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9d0b9ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acro.rename_output(list(acro.results.keys())[2], \"pivot_table\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56d2b6a1",
+   "metadata": {},
+   "source": [
+    "### Add a comment to output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e21f7b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acro.add_comments(\n",
+    "    list(acro.results.keys())[0], \"This is a cross table between year and grant_type\"\n",
+    ")\n",
+    "acro.add_comments(list(acro.results.keys())[0], \"6 cells were supressed in this table\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8496fed4",
+   "metadata": {},
+   "source": [
+    "### Add an unsupported output to the list of outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e8000a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acro.custom_output(\n",
+    "    \"XandY.jfif\", \"This output is an image showing the relationship between X and Y\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a586694",
+   "metadata": {},
+   "source": [
+    "### Finalise ACRO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f941aca2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# output = acro.finalise(\"test_results.xlsx\")\n",
+    "output = acro.finalise(\"test_results.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50c59b97",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py10",
+   "language": "python",
+   "name": "py10"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "60d460a0c8d470874289c00850b4e48e2a0f5edc6094e1c7b6df7b21a43072bf"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -302,11 +302,11 @@ def test_missing(data, acro):
     assert output[output_1]["summary"] == correct_summary
 
 
-def test_suppression_error(caplog, acro):
+def test_suppression_error(caplog):
     """Apply suppression type error test."""
-    d = {"col1": [1, 2], "col2": [3, 4]}
-    m = {"col1": [np.NaN, True], "col2": [True, True]}
-    table = pd.DataFrame(data=d)
-    masks = {"test": pd.DataFrame(data=m)}
+    table_data = {"col1": [1, 2], "col2": [3, 4]}
+    mask_data = {"col1": [np.NaN, True], "col2": [True, True]}
+    table = pd.DataFrame(data=table_data)
+    masks = {"test": pd.DataFrame(data=mask_data)}
     utils.apply_suppression(table, masks)
     assert "problem mask test is not binary" in caplog.text

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -300,3 +300,13 @@ def test_missing(data, acro):
     output_1 = list(output.keys())[1]
     assert output[output_0]["summary"] == correct_summary
     assert output[output_1]["summary"] == correct_summary
+
+
+def test_suppression_error(caplog, acro):
+    """Apply suppression type error test."""
+    d = {"col1": [1, 2], "col2": [3, 4]}
+    m = {"col1": [np.NaN, True], "col2": [True, True]}
+    table = pd.DataFrame(data=d)
+    masks = {"test": pd.DataFrame(data=m)}
+    utils.apply_suppression(table, masks)
+    assert "problem mask test is not binary" in caplog.text


### PR DESCRIPTION
Adds try-except around the call to filter using a mask  in method apply_suppression line 307 in utils.py

But principally adds some code in acro,crosstab lines 276-280 to convert empty/nan cells in masks to 1 (suppress) then converts whole mask to bools manually.

Possibly a neater way of doing this? 