### PR TITLE
Serialize outcome field as dict, not string.

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,6 +25,10 @@ authors:
   - family-names: Albashir
     given-names: Maha
     affiliation: University of the West of England
+  - family-names: Davy
+    given-names: Simon
+    affiliation: University of Oxford
+    orcid: https://orcid.org/0000-0001-9890-3619
 identifiers:
   - type: doi
     value: 10.5281/zenodo.7273903

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -81,7 +81,11 @@ def finalise_json(filename: str, results: dict) -> None:
     # convert dataframes to json
     for output_id, output in outputs.items():
         if output["outcome"] is not None:
-            output["outcome"] = output["outcome"].to_json()
+            # df.to_dict() does not always produce json serializeable structures.
+            # e.g. pivot tables have tuple keys.
+            # So we use .to_json() to ensure its serializeable, but we are
+            # going to serilize it later, so we parse it back into a dict
+            output["outcome"] = json.loads(output["outcome"].to_json())
         # save each output to a different file
         if not isinstance(output["output"], str):
             with open(

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -212,6 +212,15 @@ def test_finalise_json(data, acro):
     assert json_data[output_0_name]["output"] == os.path.abspath(
         f"outputs/{output_0_name}.csv"
     )
+    # regression check: the outcome fields are dicts not strings
+    assert json_data[output_0_name]["outcome"]["R/G"] == {
+        "2010": "threshold; ",
+        "2011": "threshold; ",
+        "2012": "threshold; ",
+        "2013": "threshold; ",
+        "2014": "threshold; ",
+        "2015": "threshold; ",
+    }
     assert json_data[output_1_name]["output"] == os.path.abspath(
         f"outputs/{output_1_name}.csv"
     )


### PR DESCRIPTION
The `df.to_json()` function returns serialized json string, which was
then serialized as string in the resulting JSON output.

This required consumers of the JSON to manually reparse the `outcome`
field as JSON for every output in order to use it.

This simple change still uses `to_json()`, to ensure that the outcome
field is JSON serialize able, but it parses it back into a python dict,
so that when the final JSON happens, we get the structured outcome field
in the JSON output, rather than a string.

Fixes #73 
