### PR TITLE
automatic table suppression disabled as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Development
 
 Changes:
-*
+*    Disable automatic table suppression by default ([#91](https://github.com/AI-SDC/ACRO/pull/91))
 
 ## Version 0.2.0 (Jun 28, 2023)
 

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -223,13 +223,16 @@ class ACRO:
             mask.replace({0: False, 1: True}, inplace=True)
             masks[name] = mask
 
-        properties: dict = {"method": "crosstab", "suppressed": False}
-        status, summary = utils.get_summary(masks, properties)
+        # build the properties dictionary
+        properties: dict = {"method": "crosstab", "suppressed": self.suppress}
+        utils.update_table_properties(masks, properties)
+        # get the status and summary
+        status, summary = utils.get_summary(properties)
+        # apply the suppression
         safe_table, outcome = utils.apply_suppression(table, masks)
         if self.suppress:
             table = safe_table
-            properties["suppressed"] = True
-
+        # record output
         self.results.add(
             status=status,
             output_type="table",
@@ -351,13 +354,16 @@ class ACRO:
                     data, values, index, columns, aggfunc=agg
                 )
 
-        properties: dict = {"method": "pivot_table", "suppressed": False}
-        status, summary = utils.get_summary(masks, properties)
+        # build the properties dictionary
+        properties: dict = {"method": "pivot_table", "suppressed": self.suppress}
+        utils.update_table_properties(masks, properties)
+        # get the status and summary
+        status, summary = utils.get_summary(properties)
+        # apply the suppression
         safe_table, outcome = utils.apply_suppression(table, masks)
         if self.suppress:
             table = safe_table
-            properties["suppressed"] = True
-
+        # record output
         self.results.add(
             status=status,
             output_type="table",

--- a/acro/record.py
+++ b/acro/record.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pandas as pd
 from pandas import DataFrame
 
-logger = logging.getLogger("acro::records")
+logger = logging.getLogger("acro:records")
 
 
 def load_outcome(outcome: dict) -> DataFrame:

--- a/notebooks/test-nursery.ipynb
+++ b/notebooks/test-nursery.ipynb
@@ -86,12 +86,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False}\n"
+      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False}\n",
+      "INFO:acro:automatic suppression: True\n"
      ]
     }
    ],
    "source": [
-    "acro = ACRO()"
+    "acro = ACRO(suppress=True)"
    ]
   },
   {
@@ -406,6 +407,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): fail; threshold: 4 cells suppressed; \n",
       "INFO:acro:outcome_df:\n",
       "parents      great_pret  pretentious        usual\n",
       "recommend                                        \n",
@@ -414,8 +416,7 @@
       "recommend   threshold;   threshold;   threshold; \n",
       "spec_prior           ok           ok           ok\n",
       "very_recom  threshold;            ok           ok\n",
-      "INFO:acro:get_summary(): fail; threshold: 4 cells suppressed; \n",
-      "INFO:acro::records:add(): output_0\n"
+      "INFO:acro:records:add(): output_0\n"
      ]
     },
     {
@@ -463,6 +464,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): fail; threshold: 4 cells suppressed; p-ratio: 4 cells suppressed; nk-rule: 4 cells suppressed; \n",
       "INFO:acro:outcome_df:\n",
       "parents                        great_pret                    pretentious  \\\n",
       "recommend                                                                  \n",
@@ -479,8 +481,7 @@
       "recommend   threshold; p-ratio; nk-rule;   \n",
       "spec_prior                             ok  \n",
       "very_recom                             ok  \n",
-      "INFO:acro:get_summary(): fail; threshold: 4 cells suppressed; p-ratio: 4 cells suppressed; nk-rule: 4 cells suppressed; \n",
-      "INFO:acro::records:add(): output_1\n"
+      "INFO:acro:records:add(): output_1\n"
      ]
     },
     {
@@ -489,11 +490,11 @@
      "text": [
       "parents     great_pret  pretentious     usual\n",
       "recommend                                    \n",
-      "not_recom     3.153472     3.139583  3.142361\n",
-      "priority      2.629371     3.008760  3.134096\n",
+      "not_recom     3.115972     3.090278  3.127778\n",
+      "priority      2.615385     3.027628  3.164241\n",
       "recommend          NaN          NaN       NaN\n",
-      "spec_prior    3.333828     3.352848  3.397098\n",
-      "very_recom         NaN     2.212121  2.234694\n"
+      "spec_prior    3.366469     3.327532  3.415567\n",
+      "very_recom         NaN     2.250000  2.244898\n"
      ]
     }
    ],
@@ -532,6 +533,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): pass\n",
       "INFO:acro:outcome_df:\n",
       "                mean      std\n",
       "            children children\n",
@@ -539,8 +541,7 @@
       "great_pret        ok       ok\n",
       "pretentious       ok       ok\n",
       "usual             ok       ok\n",
-      "INFO:acro:get_summary(): pass\n",
-      "INFO:acro::records:add(): output_2\n"
+      "INFO:acro:records:add(): output_2\n"
      ]
     },
     {
@@ -550,9 +551,9 @@
       "                 mean       std\n",
       "             children  children\n",
       "parents                        \n",
-      "great_pret   3.133796  2.253790\n",
-      "pretentious  3.128704  2.240384\n",
-      "usual        3.141204  2.256008\n"
+      "great_pret   3.133796  2.253688\n",
+      "pretentious  3.112500  2.221958\n",
+      "usual        3.153472  2.286559\n"
      ]
     }
    ],
@@ -644,7 +645,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:ols() outcome: pass; dof=12958.0 >= 10\n",
-      "INFO:acro::records:add(): output_3\n"
+      "INFO:acro:records:add(): output_3\n"
      ]
     },
     {
@@ -653,25 +654,25 @@
        "<table class=\"simpletable\">\n",
        "<caption>OLS Regression Results</caption>\n",
        "<tr>\n",
-       "  <th>Dep. Variable:</th>        <td>recommend</td>    <th>  R-squared:         </th> <td>   0.000</td> \n",
+       "  <th>Dep. Variable:</th>        <td>recommend</td>    <th>  R-squared:         </th> <td>   0.001</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Model:</th>                   <td>OLS</td>       <th>  Adj. R-squared:    </th> <td>   0.000</td> \n",
+       "  <th>Model:</th>                   <td>OLS</td>       <th>  Adj. R-squared:    </th> <td>   0.001</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Method:</th>             <td>Least Squares</td>  <th>  F-statistic:       </th> <td>   5.915</td> \n",
+       "  <th>Method:</th>             <td>Least Squares</td>  <th>  F-statistic:       </th> <td>   12.32</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>             <td>Wed, 28 Jun 2023</td> <th>  Prob (F-statistic):</th>  <td>0.0150</td>  \n",
+       "  <th>Date:</th>             <td>Thu, 29 Jun 2023</td> <th>  Prob (F-statistic):</th> <td>0.000449</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                 <td>10:49:34</td>     <th>  Log-Likelihood:    </th> <td> -25125.</td> \n",
+       "  <th>Time:</th>                 <td>15:37:47</td>     <th>  Log-Likelihood:    </th> <td> -25121.</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>No. Observations:</th>      <td> 12960</td>      <th>  AIC:               </th> <td>5.025e+04</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Df Residuals:</th>          <td> 12958</td>      <th>  BIC:               </th> <td>5.027e+04</td>\n",
+       "  <th>Df Residuals:</th>          <td> 12958</td>      <th>  BIC:               </th> <td>5.026e+04</td>\n",
        "</tr>\n",
        "<tr>\n",
        "  <th>Df Model:</th>              <td>     1</td>      <th>                     </th>     <td> </td>    \n",
@@ -685,24 +686,24 @@
        "      <td></td>        <th>coef</th>     <th>std err</th>      <th>t</th>      <th>P>|t|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>const</th>    <td>    2.2364</td> <td>    0.025</td> <td>   88.278</td> <td> 0.000</td> <td>    2.187</td> <td>    2.286</td>\n",
+       "  <th>const</th>    <td>    2.2144</td> <td>    0.025</td> <td>   87.563</td> <td> 0.000</td> <td>    2.165</td> <td>    2.264</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>children</th> <td>    0.0160</td> <td>    0.007</td> <td>    2.432</td> <td> 0.015</td> <td>    0.003</td> <td>    0.029</td>\n",
+       "  <th>children</th> <td>    0.0230</td> <td>    0.007</td> <td>    3.510</td> <td> 0.000</td> <td>    0.010</td> <td>    0.036</td>\n",
        "</tr>\n",
        "</table>\n",
        "<table class=\"simpletable\">\n",
        "<tr>\n",
-       "  <th>Omnibus:</th>       <td>76705.663</td> <th>  Durbin-Watson:     </th> <td>   2.883</td>\n",
+       "  <th>Omnibus:</th>       <td>77019.522</td> <th>  Durbin-Watson:     </th> <td>   2.883</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Prob(Omnibus):</th>  <td> 0.000</td>   <th>  Jarque-Bera (JB):  </th> <td>1743.233</td>\n",
+       "  <th>Prob(Omnibus):</th>  <td> 0.000</td>   <th>  Jarque-Bera (JB):  </th> <td>1741.735</td>\n",
        "</tr>\n",
        "<tr>\n",
        "  <th>Skew:</th>           <td>-0.485</td>   <th>  Prob(JB):          </th> <td>    0.00</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Kurtosis:</th>       <td> 1.487</td>   <th>  Cond. No.          </th> <td>    6.92</td>\n",
+       "  <th>Kurtosis:</th>       <td> 1.489</td>   <th>  Cond. No.          </th> <td>    6.91</td>\n",
        "</tr>\n",
        "</table><br/><br/>Notes:<br/>[1] Standard Errors assume that the covariance matrix of the errors is correctly specified."
       ],
@@ -711,25 +712,25 @@
        "\"\"\"\n",
        "                            OLS Regression Results                            \n",
        "==============================================================================\n",
-       "Dep. Variable:              recommend   R-squared:                       0.000\n",
-       "Model:                            OLS   Adj. R-squared:                  0.000\n",
-       "Method:                 Least Squares   F-statistic:                     5.915\n",
-       "Date:                Wed, 28 Jun 2023   Prob (F-statistic):             0.0150\n",
-       "Time:                        10:49:34   Log-Likelihood:                -25125.\n",
+       "Dep. Variable:              recommend   R-squared:                       0.001\n",
+       "Model:                            OLS   Adj. R-squared:                  0.001\n",
+       "Method:                 Least Squares   F-statistic:                     12.32\n",
+       "Date:                Thu, 29 Jun 2023   Prob (F-statistic):           0.000449\n",
+       "Time:                        15:37:47   Log-Likelihood:                -25121.\n",
        "No. Observations:               12960   AIC:                         5.025e+04\n",
-       "Df Residuals:                   12958   BIC:                         5.027e+04\n",
+       "Df Residuals:                   12958   BIC:                         5.026e+04\n",
        "Df Model:                           1                                         \n",
        "Covariance Type:            nonrobust                                         \n",
        "==============================================================================\n",
        "                 coef    std err          t      P>|t|      [0.025      0.975]\n",
        "------------------------------------------------------------------------------\n",
-       "const          2.2364      0.025     88.278      0.000       2.187       2.286\n",
-       "children       0.0160      0.007      2.432      0.015       0.003       0.029\n",
+       "const          2.2144      0.025     87.563      0.000       2.165       2.264\n",
+       "children       0.0230      0.007      3.510      0.000       0.010       0.036\n",
        "==============================================================================\n",
-       "Omnibus:                    76705.663   Durbin-Watson:                   2.883\n",
-       "Prob(Omnibus):                  0.000   Jarque-Bera (JB):             1743.233\n",
+       "Omnibus:                    77019.522   Durbin-Watson:                   2.883\n",
+       "Prob(Omnibus):                  0.000   Jarque-Bera (JB):             1741.735\n",
        "Skew:                          -0.485   Prob(JB):                         0.00\n",
-       "Kurtosis:                       1.487   Cond. No.                         6.92\n",
+       "Kurtosis:                       1.489   Cond. No.                         6.91\n",
        "==============================================================================\n",
        "\n",
        "Notes:\n",
@@ -779,7 +780,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:olsr() outcome: pass; dof=12958.0 >= 10\n",
-      "INFO:acro::records:add(): output_4\n"
+      "INFO:acro:records:add(): output_4\n"
      ]
     },
     {
@@ -788,25 +789,25 @@
      "text": [
       "                            OLS Regression Results                            \n",
       "==============================================================================\n",
-      "Dep. Variable:              recommend   R-squared:                       0.000\n",
-      "Model:                            OLS   Adj. R-squared:                  0.000\n",
-      "Method:                 Least Squares   F-statistic:                     5.915\n",
-      "Date:                Wed, 28 Jun 2023   Prob (F-statistic):             0.0150\n",
-      "Time:                        10:49:34   Log-Likelihood:                -25125.\n",
+      "Dep. Variable:              recommend   R-squared:                       0.001\n",
+      "Model:                            OLS   Adj. R-squared:                  0.001\n",
+      "Method:                 Least Squares   F-statistic:                     12.32\n",
+      "Date:                Thu, 29 Jun 2023   Prob (F-statistic):           0.000449\n",
+      "Time:                        15:37:47   Log-Likelihood:                -25121.\n",
       "No. Observations:               12960   AIC:                         5.025e+04\n",
-      "Df Residuals:                   12958   BIC:                         5.027e+04\n",
+      "Df Residuals:                   12958   BIC:                         5.026e+04\n",
       "Df Model:                           1                                         \n",
       "Covariance Type:            nonrobust                                         \n",
       "==============================================================================\n",
       "                 coef    std err          t      P>|t|      [0.025      0.975]\n",
       "------------------------------------------------------------------------------\n",
-      "Intercept      2.2364      0.025     88.278      0.000       2.187       2.286\n",
-      "children       0.0160      0.007      2.432      0.015       0.003       0.029\n",
+      "Intercept      2.2144      0.025     87.563      0.000       2.165       2.264\n",
+      "children       0.0230      0.007      3.510      0.000       0.010       0.036\n",
       "==============================================================================\n",
-      "Omnibus:                    76705.663   Durbin-Watson:                   2.883\n",
-      "Prob(Omnibus):                  0.000   Jarque-Bera (JB):             1743.233\n",
+      "Omnibus:                    77019.522   Durbin-Watson:                   2.883\n",
+      "Prob(Omnibus):                  0.000   Jarque-Bera (JB):             1741.735\n",
       "Skew:                          -0.485   Prob(JB):                         0.00\n",
-      "Kurtosis:                       1.487   Cond. No.                         6.92\n",
+      "Kurtosis:                       1.489   Cond. No.                         6.91\n",
       "==============================================================================\n",
       "\n",
       "Notes:\n",
@@ -850,7 +851,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:probit() outcome: pass; dof=12958.0 >= 10\n",
-      "INFO:acro::records:add(): output_5\n"
+      "INFO:acro:records:add(): output_5\n"
      ]
     },
     {
@@ -858,22 +859,22 @@
      "output_type": "stream",
      "text": [
       "Optimization terminated successfully.\n",
-      "         Current function value: 0.693147\n",
-      "         Iterations 2\n",
+      "         Current function value: 0.693143\n",
+      "         Iterations 3\n",
       "                          Probit Regression Results                           \n",
       "==============================================================================\n",
       "Dep. Variable:                finance   No. Observations:                12960\n",
       "Model:                         Probit   Df Residuals:                    12958\n",
       "Method:                           MLE   Df Model:                            1\n",
-      "Date:                Wed, 28 Jun 2023   Pseudo R-squ.:               1.663e-07\n",
-      "Time:                        10:49:34   Log-Likelihood:                -8983.2\n",
+      "Date:                Thu, 29 Jun 2023   Pseudo R-squ.:               5.823e-06\n",
+      "Time:                        15:37:47   Log-Likelihood:                -8983.1\n",
       "converged:                       True   LL-Null:                       -8983.2\n",
-      "Covariance Type:            nonrobust   LLR p-value:                    0.9564\n",
+      "Covariance Type:            nonrobust   LLR p-value:                    0.7463\n",
       "==============================================================================\n",
       "                 coef    std err          z      P>|z|      [0.025      0.975]\n",
       "------------------------------------------------------------------------------\n",
-      "const          0.0008      0.019      0.044      0.965      -0.036       0.038\n",
-      "children      -0.0003      0.005     -0.055      0.956      -0.010       0.009\n",
+      "const          0.0050      0.019      0.263      0.793      -0.032       0.042\n",
+      "children      -0.0016      0.005     -0.323      0.746      -0.011       0.008\n",
       "==============================================================================\n"
      ]
     }
@@ -919,7 +920,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:logit() outcome: pass; dof=12958.0 >= 10\n",
-      "INFO:acro::records:add(): output_6\n"
+      "INFO:acro:records:add(): output_6\n"
      ]
     },
     {
@@ -927,8 +928,8 @@
      "output_type": "stream",
      "text": [
       "Optimization terminated successfully.\n",
-      "         Current function value: 0.693147\n",
-      "         Iterations 2\n"
+      "         Current function value: 0.693143\n",
+      "         Iterations 3\n"
      ]
     },
     {
@@ -946,16 +947,16 @@
        "  <th>Method:</th>                 <td>MLE</td>       <th>  Df Model:          </th>  <td>     1</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>            <td>Wed, 28 Jun 2023</td> <th>  Pseudo R-squ.:     </th> <td>1.663e-07</td>\n",
+       "  <th>Date:</th>            <td>Thu, 29 Jun 2023</td> <th>  Pseudo R-squ.:     </th> <td>5.823e-06</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                <td>10:49:34</td>     <th>  Log-Likelihood:    </th> <td> -8983.2</td> \n",
+       "  <th>Time:</th>                <td>15:37:47</td>     <th>  Log-Likelihood:    </th> <td> -8983.1</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>converged:</th>             <td>True</td>       <th>  LL-Null:           </th> <td> -8983.2</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Covariance Type:</th>     <td>nonrobust</td>    <th>  LLR p-value:       </th>  <td>0.9564</td>  \n",
+       "  <th>Covariance Type:</th>     <td>nonrobust</td>    <th>  LLR p-value:       </th>  <td>0.7463</td>  \n",
        "</tr>\n",
        "</table>\n",
        "<table class=\"simpletable\">\n",
@@ -963,10 +964,10 @@
        "      <td></td>        <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>const</th>    <td>    0.0013</td> <td>    0.030</td> <td>    0.044</td> <td> 0.965</td> <td>   -0.058</td> <td>    0.060</td>\n",
+       "  <th>const</th>    <td>    0.0079</td> <td>    0.030</td> <td>    0.263</td> <td> 0.793</td> <td>   -0.051</td> <td>    0.067</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>children</th> <td>   -0.0004</td> <td>    0.008</td> <td>   -0.055</td> <td> 0.956</td> <td>   -0.016</td> <td>    0.015</td>\n",
+       "  <th>children</th> <td>   -0.0025</td> <td>    0.008</td> <td>   -0.323</td> <td> 0.746</td> <td>   -0.018</td> <td>    0.013</td>\n",
        "</tr>\n",
        "</table>"
       ],
@@ -978,15 +979,15 @@
        "Dep. Variable:                finance   No. Observations:                12960\n",
        "Model:                          Logit   Df Residuals:                    12958\n",
        "Method:                           MLE   Df Model:                            1\n",
-       "Date:                Wed, 28 Jun 2023   Pseudo R-squ.:               1.663e-07\n",
-       "Time:                        10:49:34   Log-Likelihood:                -8983.2\n",
+       "Date:                Thu, 29 Jun 2023   Pseudo R-squ.:               5.823e-06\n",
+       "Time:                        15:37:47   Log-Likelihood:                -8983.1\n",
        "converged:                       True   LL-Null:                       -8983.2\n",
-       "Covariance Type:            nonrobust   LLR p-value:                    0.9564\n",
+       "Covariance Type:            nonrobust   LLR p-value:                    0.7463\n",
        "==============================================================================\n",
        "                 coef    std err          z      P>|z|      [0.025      0.975]\n",
        "------------------------------------------------------------------------------\n",
-       "const          0.0013      0.030      0.044      0.965      -0.058       0.060\n",
-       "children      -0.0004      0.008     -0.055      0.956      -0.016       0.015\n",
+       "const          0.0079      0.030      0.263      0.793      -0.051       0.067\n",
+       "children      -0.0025      0.008     -0.323      0.746      -0.018       0.013\n",
        "==============================================================================\n",
        "\"\"\""
       ]
@@ -1035,7 +1036,7 @@
       "uid: output_0\n",
       "status: fail\n",
       "type: table\n",
-      "properties: {'method': 'crosstab', 'negative': False, 'missing': False, 'threshold': 4, 'p-ratio': 0, 'nk-rule': 0}\n",
+      "properties: {'method': 'crosstab', 'suppressed': True, 'negative': False, 'missing': False, 'threshold': 4, 'p-ratio': 0, 'nk-rule': 0}\n",
       "command: safe_table = acro.crosstab(df.recommend, df.parents)\n",
       "summary: fail; threshold: 4 cells suppressed; \n",
       "outcome: {'great_pret': {'not_recom': 'ok', 'priority': 'ok', 'recommend': 'threshold; ', 'spec_prior': 'ok', 'very_recom': 'threshold; '}, 'pretentious': {'not_recom': 'ok', 'priority': 'ok', 'recommend': 'threshold; ', 'spec_prior': 'ok', 'very_recom': 'ok'}, 'usual': {'not_recom': 'ok', 'priority': 'ok', 'recommend': 'threshold; ', 'spec_prior': 'ok', 'very_recom': 'ok'}}\n",
@@ -1046,7 +1047,7 @@
       "recommend          NaN          NaN     NaN\n",
       "spec_prior      2022.0       1264.0   758.0\n",
       "very_recom         NaN        132.0   196.0]\n",
-      "timestamp: 2023-06-28T10:49:34.678203\n",
+      "timestamp: 2023-06-29T15:37:47.179430\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1054,18 +1055,18 @@
       "uid: output_1\n",
       "status: fail\n",
       "type: table\n",
-      "properties: {'method': 'crosstab', 'negative': False, 'missing': False, 'threshold': 4, 'p-ratio': 4, 'nk-rule': 4}\n",
+      "properties: {'method': 'crosstab', 'suppressed': True, 'negative': False, 'missing': False, 'threshold': 4, 'p-ratio': 4, 'nk-rule': 4}\n",
       "command: safe_table = acro.crosstab(df.recommend, df.parents, values=df.children, aggfunc=\"mean\")\n",
       "summary: fail; threshold: 4 cells suppressed; p-ratio: 4 cells suppressed; nk-rule: 4 cells suppressed; \n",
       "outcome: {'great_pret': {'not_recom': 'ok', 'priority': 'ok', 'recommend': 'threshold; p-ratio; nk-rule; ', 'spec_prior': 'ok', 'very_recom': 'threshold; p-ratio; nk-rule; '}, 'pretentious': {'not_recom': 'ok', 'priority': 'ok', 'recommend': 'threshold; p-ratio; nk-rule; ', 'spec_prior': 'ok', 'very_recom': 'ok'}, 'usual': {'not_recom': 'ok', 'priority': 'ok', 'recommend': 'threshold; p-ratio; nk-rule; ', 'spec_prior': 'ok', 'very_recom': 'ok'}}\n",
       "output: [parents     great_pret  pretentious     usual\n",
       "recommend                                    \n",
-      "not_recom     3.153472     3.139583  3.142361\n",
-      "priority      2.629371     3.008760  3.134096\n",
+      "not_recom     3.115972     3.090278  3.127778\n",
+      "priority      2.615385     3.027628  3.164241\n",
       "recommend          NaN          NaN       NaN\n",
-      "spec_prior    3.333828     3.352848  3.397098\n",
-      "very_recom         NaN     2.212121  2.234694]\n",
-      "timestamp: 2023-06-28T10:49:34.724713\n",
+      "spec_prior    3.366469     3.327532  3.415567\n",
+      "very_recom         NaN     2.250000  2.244898]\n",
+      "timestamp: 2023-06-29T15:37:47.229037\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1073,17 +1074,17 @@
       "uid: output_2\n",
       "status: pass\n",
       "type: table\n",
-      "properties: {'method': 'pivot_table', 'negative': False, 'missing': False, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
+      "properties: {'method': 'pivot_table', 'suppressed': True, 'negative': False, 'missing': False, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
       "command: table = acro.pivot_table(\n",
       "summary: pass\n",
       "outcome: {\"('mean', 'children')\": {'great_pret': 'ok', 'pretentious': 'ok', 'usual': 'ok'}, \"('std', 'children')\": {'great_pret': 'ok', 'pretentious': 'ok', 'usual': 'ok'}}\n",
       "output: [                 mean       std\n",
       "             children  children\n",
       "parents                        \n",
-      "great_pret   3.133796  2.253790\n",
-      "pretentious  3.128704  2.240384\n",
-      "usual        3.141204  2.256008]\n",
-      "timestamp: 2023-06-28T10:49:34.774011\n",
+      "great_pret   3.133796  2.253688\n",
+      "pretentious  3.112500  2.221958\n",
+      "usual        3.153472  2.286559]\n",
+      "timestamp: 2023-06-29T15:37:47.283051\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1095,23 +1096,23 @@
       "command: results = acro.ols(y, x)\n",
       "summary: pass; dof=12958.0 >= 10\n",
       "outcome: {}\n",
-      "output: [                          recommend           R-squared:      0.000\n",
-      "Dep. Variable:                                                     \n",
-      "Model:                          OLS      Adj. R-squared:      0.000\n",
-      "Method:               Least Squares         F-statistic:      5.915\n",
-      "Date:              Wed, 28 Jun 2023  Prob (F-statistic):      0.015\n",
-      "Time:                      10:49:34      Log-Likelihood: -25125.000\n",
-      "No. Observations:             12960                 AIC:  50250.000\n",
-      "Df Residuals:                 12958                 BIC:  50270.000\n",
-      "Df Model:                         1                  NaN        NaN\n",
-      "Covariance Type:          nonrobust                  NaN        NaN,             coef  std err       t  P>|t|  [0.025  0.975]\n",
-      "const     2.2364    0.025  88.278  0.000   2.187   2.286\n",
-      "children  0.0160    0.007   2.432  0.015   0.003   0.029,                 76705.663     Durbin-Watson:     2.883\n",
+      "output: [                          recommend           R-squared:         0.001\n",
+      "Dep. Variable:                                                        \n",
+      "Model:                          OLS      Adj. R-squared:      0.001000\n",
+      "Method:               Least Squares         F-statistic:     12.320000\n",
+      "Date:              Thu, 29 Jun 2023  Prob (F-statistic):      0.000449\n",
+      "Time:                      15:37:47      Log-Likelihood: -25121.000000\n",
+      "No. Observations:             12960                 AIC:  50250.000000\n",
+      "Df Residuals:                 12958                 BIC:  50260.000000\n",
+      "Df Model:                         1                  NaN           NaN\n",
+      "Covariance Type:          nonrobust                  NaN           NaN,             coef  std err       t  P>|t|  [0.025  0.975]\n",
+      "const     2.2144    0.025  87.563    0.0   2.165   2.264\n",
+      "children  0.0230    0.007   3.510    0.0   0.010   0.036,                 77019.522     Durbin-Watson:     2.883\n",
       "Omnibus:                                              \n",
-      "Prob(Omnibus):      0.000  Jarque-Bera (JB):  1743.233\n",
+      "Prob(Omnibus):      0.000  Jarque-Bera (JB):  1741.735\n",
       "Skew:              -0.485          Prob(JB):     0.000\n",
-      "Kurtosis:           1.487          Cond. No.     6.920]\n",
-      "timestamp: 2023-06-28T10:49:34.878164\n",
+      "Kurtosis:           1.489          Cond. No.     6.910]\n",
+      "timestamp: 2023-06-29T15:37:47.384052\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1123,23 +1124,23 @@
       "command: results = acro.olsr(formula=\"recommend ~ children\", data=new_df)\n",
       "summary: pass; dof=12958.0 >= 10\n",
       "outcome: {}\n",
-      "output: [                          recommend           R-squared:      0.000\n",
-      "Dep. Variable:                                                     \n",
-      "Model:                          OLS      Adj. R-squared:      0.000\n",
-      "Method:               Least Squares         F-statistic:      5.915\n",
-      "Date:              Wed, 28 Jun 2023  Prob (F-statistic):      0.015\n",
-      "Time:                      10:49:34      Log-Likelihood: -25125.000\n",
-      "No. Observations:             12960                 AIC:  50250.000\n",
-      "Df Residuals:                 12958                 BIC:  50270.000\n",
-      "Df Model:                         1                  NaN        NaN\n",
-      "Covariance Type:          nonrobust                  NaN        NaN,              coef  std err       t  P>|t|  [0.025  0.975]\n",
-      "Intercept  2.2364    0.025  88.278  0.000   2.187   2.286\n",
-      "children   0.0160    0.007   2.432  0.015   0.003   0.029,                 76705.663     Durbin-Watson:     2.883\n",
+      "output: [                          recommend           R-squared:         0.001\n",
+      "Dep. Variable:                                                        \n",
+      "Model:                          OLS      Adj. R-squared:      0.001000\n",
+      "Method:               Least Squares         F-statistic:     12.320000\n",
+      "Date:              Thu, 29 Jun 2023  Prob (F-statistic):      0.000449\n",
+      "Time:                      15:37:47      Log-Likelihood: -25121.000000\n",
+      "No. Observations:             12960                 AIC:  50250.000000\n",
+      "Df Residuals:                 12958                 BIC:  50260.000000\n",
+      "Df Model:                         1                  NaN           NaN\n",
+      "Covariance Type:          nonrobust                  NaN           NaN,              coef  std err       t  P>|t|  [0.025  0.975]\n",
+      "Intercept  2.2144    0.025  87.563    0.0   2.165   2.264\n",
+      "children   0.0230    0.007   3.510    0.0   0.010   0.036,                 77019.522     Durbin-Watson:     2.883\n",
       "Omnibus:                                              \n",
-      "Prob(Omnibus):      0.000  Jarque-Bera (JB):  1743.233\n",
+      "Prob(Omnibus):      0.000  Jarque-Bera (JB):  1741.735\n",
       "Skew:              -0.485          Prob(JB):     0.000\n",
-      "Kurtosis:           1.487          Cond. No.     6.920]\n",
-      "timestamp: 2023-06-28T10:49:34.918103\n",
+      "Kurtosis:           1.489          Cond. No.     6.910]\n",
+      "timestamp: 2023-06-29T15:37:47.422827\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1153,15 +1154,15 @@
       "outcome: {}\n",
       "output: [                           finance No. Observations:         12960\n",
       "Dep. Variable:                                                    \n",
-      "Model:                      Probit     Df Residuals:  1.295800e+04\n",
-      "Method:                        MLE         Df Model:  1.000000e+00\n",
-      "Date:             Wed, 28 Jun 2023    Pseudo R-squ.:  1.663000e-07\n",
-      "Time:                     10:49:34   Log-Likelihood: -8.983200e+03\n",
-      "converged:                    True          LL-Null: -8.983200e+03\n",
-      "Covariance Type:         nonrobust      LLR p-value:  9.564000e-01,             coef  std err      z  P>|z|  [0.025  0.975]\n",
-      "const     0.0008    0.019  0.044  0.965  -0.036   0.038\n",
-      "children -0.0003    0.005 -0.055  0.956  -0.010   0.009]\n",
-      "timestamp: 2023-06-28T10:49:34.962654\n",
+      "Model:                      Probit     Df Residuals:  12958.000000\n",
+      "Method:                        MLE         Df Model:      1.000000\n",
+      "Date:             Thu, 29 Jun 2023    Pseudo R-squ.:      0.000006\n",
+      "Time:                     15:37:47   Log-Likelihood:  -8983.100000\n",
+      "converged:                    True          LL-Null:  -8983.200000\n",
+      "Covariance Type:         nonrobust      LLR p-value:      0.746300,             coef  std err      z  P>|z|  [0.025  0.975]\n",
+      "const     0.0050    0.019  0.263  0.793  -0.032   0.042\n",
+      "children -0.0016    0.005 -0.323  0.746  -0.011   0.008]\n",
+      "timestamp: 2023-06-29T15:37:47.465800\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1175,15 +1176,15 @@
       "outcome: {}\n",
       "output: [                           finance No. Observations:         12960\n",
       "Dep. Variable:                                                    \n",
-      "Model:                       Logit     Df Residuals:  1.295800e+04\n",
-      "Method:                        MLE         Df Model:  1.000000e+00\n",
-      "Date:             Wed, 28 Jun 2023    Pseudo R-squ.:  1.663000e-07\n",
-      "Time:                     10:49:34   Log-Likelihood: -8.983200e+03\n",
-      "converged:                    True          LL-Null: -8.983200e+03\n",
-      "Covariance Type:         nonrobust      LLR p-value:  9.564000e-01,             coef  std err      z  P>|z|  [0.025  0.975]\n",
-      "const     0.0013    0.030  0.044  0.965  -0.058   0.060\n",
-      "children -0.0004    0.008 -0.055  0.956  -0.016   0.015]\n",
-      "timestamp: 2023-06-28T10:49:34.999261\n",
+      "Model:                       Logit     Df Residuals:  12958.000000\n",
+      "Method:                        MLE         Df Model:      1.000000\n",
+      "Date:             Thu, 29 Jun 2023    Pseudo R-squ.:      0.000006\n",
+      "Time:                     15:37:47   Log-Likelihood:  -8983.100000\n",
+      "converged:                    True          LL-Null:  -8983.200000\n",
+      "Covariance Type:         nonrobust      LLR p-value:      0.746300,             coef  std err      z  P>|z|  [0.025  0.975]\n",
+      "const     0.0079    0.030  0.263  0.793  -0.051   0.067\n",
+      "children -0.0025    0.008 -0.323  0.746  -0.018   0.013]\n",
+      "timestamp: 2023-06-29T15:37:47.504247\n",
       "comments: []\n",
       "\n",
       "\n"
@@ -1225,7 +1226,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro::records:remove(): output_0 removed\n"
+      "INFO:acro:records:remove(): output_0 removed\n"
      ]
     }
    ],
@@ -1261,7 +1262,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro::records:rename_output(): output_2 renamed to pivot_table\n"
+      "INFO:acro:records:rename_output(): output_2 renamed to pivot_table\n"
      ]
     }
    ],
@@ -1297,8 +1298,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro::records:a comment was added to output_1\n",
-      "INFO:acro::records:a comment was added to output_1\n"
+      "INFO:acro:records:a comment was added to output_1\n",
+      "INFO:acro:records:a comment was added to output_1\n"
      ]
     }
    ],
@@ -1366,7 +1367,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro::records:outputs written to: NURSERY\n"
+      "INFO:acro:records:outputs written to: NURSERY\n"
      ]
     }
    ],

--- a/notebooks/test.ipynb
+++ b/notebooks/test.ipynb
@@ -63,12 +63,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False}\n"
+      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False}\n",
+      "INFO:acro:automatic suppression: True\n"
      ]
     }
    ],
    "source": [
-    "acro = ACRO()"
+    "acro = ACRO(suppress=True)"
    ]
   },
   {
@@ -443,6 +444,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): fail; threshold: 6 cells suppressed; \n",
       "INFO:acro:outcome_df:\n",
       "grant_type   G   N   R          R/G\n",
       "year                               \n",
@@ -452,8 +454,7 @@
       "2013        ok  ok  ok  threshold; \n",
       "2014        ok  ok  ok  threshold; \n",
       "2015        ok  ok  ok  threshold; \n",
-      "INFO:acro:get_summary(): fail; threshold: 6 cells suppressed; \n",
-      "INFO:acro::records:add(): output_0\n"
+      "INFO:acro:records:add(): output_0\n"
      ]
     },
     {
@@ -578,6 +579,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): fail; threshold: 6 cells suppressed; p-ratio: 1 cells suppressed; nk-rule: 1 cells suppressed; \n",
       "INFO:acro:outcome_df:\n",
       "grant_type   G   N   R                            R/G\n",
       "year                                                 \n",
@@ -587,8 +589,7 @@
       "2013        ok  ok  ok                    threshold; \n",
       "2014        ok  ok  ok                    threshold; \n",
       "2015        ok  ok  ok                    threshold; \n",
-      "INFO:acro:get_summary(): fail; threshold: 6 cells suppressed; p-ratio: 1 cells suppressed; nk-rule: 1 cells suppressed; \n",
-      "INFO:acro::records:add(): output_1\n"
+      "INFO:acro:records:add(): output_1\n"
      ]
     },
     {
@@ -711,6 +712,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): review; missing values found\n",
       "INFO:acro:outcome_df:\n",
       "grant_type        G        N        R      R/G\n",
       "year                                          \n",
@@ -720,8 +722,7 @@
       "2013                 missing  missing         \n",
       "2014                 missing  missing         \n",
       "2015        missing  missing  missing         \n",
-      "INFO:acro:get_summary(): review; missing values found\n",
-      "INFO:acro::records:add(): output_2\n"
+      "INFO:acro:records:add(): output_2\n"
      ]
     },
     {
@@ -859,6 +860,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): review; negative values found\n",
       "INFO:acro:outcome_df:\n",
       "grant_type G         N         R R/G\n",
       "year                                \n",
@@ -868,8 +870,7 @@
       "2013          negative  negative    \n",
       "2014          negative  negative    \n",
       "2015          negative  negative    \n",
-      "INFO:acro:get_summary(): review; negative values found\n",
-      "INFO:acro::records:add(): output_3\n"
+      "INFO:acro:records:add(): output_3\n"
      ]
     },
     {
@@ -997,6 +998,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): pass\n",
       "INFO:acro:outcome_df:\n",
       "                 mean        std\n",
       "           inc_grants inc_grants\n",
@@ -1005,8 +1007,7 @@
       "N                  ok         ok\n",
       "R                  ok         ok\n",
       "R/G                ok         ok\n",
-      "INFO:acro:get_summary(): pass\n",
-      "INFO:acro::records:add(): output_4\n"
+      "INFO:acro:records:add(): output_4\n"
      ]
     },
     {
@@ -1113,6 +1114,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): review; missing values found\n",
       "INFO:acro:outcome_df:\n",
       "                 mean        std\n",
       "           inc_grants inc_grants\n",
@@ -1121,8 +1123,7 @@
       "N             missing    missing\n",
       "R             missing    missing\n",
       "R/G           missing    missing\n",
-      "INFO:acro:get_summary(): review; missing values found\n",
-      "INFO:acro::records:add(): output_5\n"
+      "INFO:acro:records:add(): output_5\n"
      ]
     },
     {
@@ -1243,6 +1244,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "INFO:acro:get_summary(): review; negative values found\n",
       "INFO:acro:outcome_df:\n",
       "                 mean        std\n",
       "           inc_grants inc_grants\n",
@@ -1251,8 +1253,7 @@
       "N            negative   negative\n",
       "R            negative   negative\n",
       "R/G                             \n",
-      "INFO:acro:get_summary(): review; negative values found\n",
-      "INFO:acro::records:add(): output_6\n"
+      "INFO:acro:records:add(): output_6\n"
      ]
     },
     {
@@ -1364,7 +1365,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:ols() outcome: pass; dof=807.0 >= 10\n",
-      "INFO:acro::records:add(): output_7\n"
+      "INFO:acro:records:add(): output_7\n"
      ]
     },
     {
@@ -1382,10 +1383,10 @@
        "  <th>Method:</th>             <td>Least Squares</td>  <th>  F-statistic:       </th> <td>   2261.</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>             <td>Wed, 28 Jun 2023</td> <th>  Prob (F-statistic):</th>  <td>  0.00</td>  \n",
+       "  <th>Date:</th>             <td>Thu, 29 Jun 2023</td> <th>  Prob (F-statistic):</th>  <td>  0.00</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                 <td>10:49:18</td>     <th>  Log-Likelihood:    </th> <td> -14495.</td> \n",
+       "  <th>Time:</th>                 <td>15:34:25</td>     <th>  Log-Likelihood:    </th> <td> -14495.</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>No. Observations:</th>      <td>   811</td>      <th>  AIC:               </th> <td>2.900e+04</td>\n",
@@ -1440,8 +1441,8 @@
        "Dep. Variable:           inc_activity   R-squared:                       0.894\n",
        "Model:                            OLS   Adj. R-squared:                  0.893\n",
        "Method:                 Least Squares   F-statistic:                     2261.\n",
-       "Date:                Wed, 28 Jun 2023   Prob (F-statistic):               0.00\n",
-       "Time:                        10:49:18   Log-Likelihood:                -14495.\n",
+       "Date:                Thu, 29 Jun 2023   Prob (F-statistic):               0.00\n",
+       "Time:                        15:34:25   Log-Likelihood:                -14495.\n",
        "No. Observations:                 811   AIC:                         2.900e+04\n",
        "Df Residuals:                     807   BIC:                         2.902e+04\n",
        "Df Model:                           3                                         \n",
@@ -1503,7 +1504,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:olsr() outcome: pass; dof=807.0 >= 10\n",
-      "INFO:acro::records:add(): output_8\n"
+      "INFO:acro:records:add(): output_8\n"
      ]
     },
     {
@@ -1521,10 +1522,10 @@
        "  <th>Method:</th>             <td>Least Squares</td>  <th>  F-statistic:       </th> <td>   2261.</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>             <td>Wed, 28 Jun 2023</td> <th>  Prob (F-statistic):</th>  <td>  0.00</td>  \n",
+       "  <th>Date:</th>             <td>Thu, 29 Jun 2023</td> <th>  Prob (F-statistic):</th>  <td>  0.00</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                 <td>10:49:18</td>     <th>  Log-Likelihood:    </th> <td> -14495.</td> \n",
+       "  <th>Time:</th>                 <td>15:34:25</td>     <th>  Log-Likelihood:    </th> <td> -14495.</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>No. Observations:</th>      <td>   811</td>      <th>  AIC:               </th> <td>2.900e+04</td>\n",
@@ -1579,8 +1580,8 @@
        "Dep. Variable:           inc_activity   R-squared:                       0.894\n",
        "Model:                            OLS   Adj. R-squared:                  0.893\n",
        "Method:                 Least Squares   F-statistic:                     2261.\n",
-       "Date:                Wed, 28 Jun 2023   Prob (F-statistic):               0.00\n",
-       "Time:                        10:49:18   Log-Likelihood:                -14495.\n",
+       "Date:                Thu, 29 Jun 2023   Prob (F-statistic):               0.00\n",
+       "Time:                        15:34:25   Log-Likelihood:                -14495.\n",
        "No. Observations:                 811   AIC:                         2.900e+04\n",
        "Df Residuals:                     807   BIC:                         2.902e+04\n",
        "Df Model:                           3                                         \n",
@@ -1637,7 +1638,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:probit() outcome: pass; dof=806.0 >= 10\n",
-      "INFO:acro::records:add(): output_9\n"
+      "INFO:acro:records:add(): output_9\n"
      ]
     },
     {
@@ -1664,10 +1665,10 @@
        "  <th>Method:</th>                 <td>MLE</td>       <th>  Df Model:          </th>  <td>     4</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>            <td>Wed, 28 Jun 2023</td> <th>  Pseudo R-squ.:     </th>  <td>0.2140</td>  \n",
+       "  <th>Date:</th>            <td>Thu, 29 Jun 2023</td> <th>  Pseudo R-squ.:     </th>  <td>0.2140</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                <td>10:49:18</td>     <th>  Log-Likelihood:    </th> <td> -400.46</td> \n",
+       "  <th>Time:</th>                <td>15:34:25</td>     <th>  Log-Likelihood:    </th> <td> -400.46</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>converged:</th>             <td>True</td>       <th>  LL-Null:           </th> <td> -509.50</td> \n",
@@ -1705,8 +1706,8 @@
        "Dep. Variable:               survivor   No. Observations:                  811\n",
        "Model:                         Probit   Df Residuals:                      806\n",
        "Method:                           MLE   Df Model:                            4\n",
-       "Date:                Wed, 28 Jun 2023   Pseudo R-squ.:                  0.2140\n",
-       "Time:                        10:49:18   Log-Likelihood:                -400.46\n",
+       "Date:                Thu, 29 Jun 2023   Pseudo R-squ.:                  0.2140\n",
+       "Time:                        15:34:25   Log-Likelihood:                -400.46\n",
        "converged:                       True   LL-Null:                       -509.50\n",
        "Covariance Type:            nonrobust   LLR p-value:                 4.875e-46\n",
        "=================================================================================\n",
@@ -1762,7 +1763,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:logit() outcome: pass; dof=806.0 >= 10\n",
-      "INFO:acro::records:add(): output_10\n"
+      "INFO:acro:records:add(): output_10\n"
      ]
     },
     {
@@ -1789,10 +1790,10 @@
        "  <th>Method:</th>                 <td>MLE</td>       <th>  Df Model:          </th>  <td>     4</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>            <td>Wed, 28 Jun 2023</td> <th>  Pseudo R-squ.:     </th>  <td>0.2187</td>  \n",
+       "  <th>Date:</th>            <td>Thu, 29 Jun 2023</td> <th>  Pseudo R-squ.:     </th>  <td>0.2187</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                <td>10:49:18</td>     <th>  Log-Likelihood:    </th> <td> -398.07</td> \n",
+       "  <th>Time:</th>                <td>15:34:25</td>     <th>  Log-Likelihood:    </th> <td> -398.07</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>converged:</th>             <td>True</td>       <th>  LL-Null:           </th> <td> -509.50</td> \n",
@@ -1830,8 +1831,8 @@
        "Dep. Variable:               survivor   No. Observations:                  811\n",
        "Model:                          Logit   Df Residuals:                      806\n",
        "Method:                           MLE   Df Model:                            4\n",
-       "Date:                Wed, 28 Jun 2023   Pseudo R-squ.:                  0.2187\n",
-       "Time:                        10:49:18   Log-Likelihood:                -398.07\n",
+       "Date:                Thu, 29 Jun 2023   Pseudo R-squ.:                  0.2187\n",
+       "Time:                        15:34:25   Log-Likelihood:                -398.07\n",
        "converged:                       True   LL-Null:                       -509.50\n",
        "Covariance Type:            nonrobust   LLR p-value:                 4.532e-47\n",
        "=================================================================================\n",
@@ -1884,7 +1885,7 @@
       "uid: output_0\n",
       "status: fail\n",
       "type: table\n",
-      "properties: {'method': 'crosstab', 'negative': False, 'missing': False, 'threshold': 6, 'p-ratio': 0, 'nk-rule': 0}\n",
+      "properties: {'method': 'crosstab', 'suppressed': True, 'negative': False, 'missing': False, 'threshold': 6, 'p-ratio': 0, 'nk-rule': 0}\n",
       "command: safe_table = acro.crosstab(df.year, df.grant_type)\n",
       "summary: fail; threshold: 6 cells suppressed; \n",
       "outcome: {'G': {'2010': 'ok', '2011': 'ok', '2012': 'ok', '2013': 'ok', '2014': 'ok', '2015': 'ok'}, 'N': {'2010': 'ok', '2011': 'ok', '2012': 'ok', '2013': 'ok', '2014': 'ok', '2015': 'ok'}, 'R': {'2010': 'ok', '2011': 'ok', '2012': 'ok', '2013': 'ok', '2014': 'ok', '2015': 'ok'}, 'R/G': {'2010': 'threshold; ', '2011': 'threshold; ', '2012': 'threshold; ', '2013': 'threshold; ', '2014': 'threshold; ', '2015': 'threshold; '}}\n",
@@ -1896,7 +1897,7 @@
       "2013        15  59  71  NaN\n",
       "2014        15  59  71  NaN\n",
       "2015        15  59  71  NaN]\n",
-      "timestamp: 2023-06-28T10:49:17.966635\n",
+      "timestamp: 2023-06-29T15:34:25.343673\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1904,7 +1905,7 @@
       "uid: output_1\n",
       "status: fail\n",
       "type: table\n",
-      "properties: {'method': 'crosstab', 'negative': False, 'missing': False, 'threshold': 6, 'p-ratio': 1, 'nk-rule': 1}\n",
+      "properties: {'method': 'crosstab', 'suppressed': True, 'negative': False, 'missing': False, 'threshold': 6, 'p-ratio': 1, 'nk-rule': 1}\n",
       "command: safe_table = acro.crosstab(df.year, df.grant_type, values=df.inc_grants, aggfunc=\"mean\")\n",
       "summary: fail; threshold: 6 cells suppressed; p-ratio: 1 cells suppressed; nk-rule: 1 cells suppressed; \n",
       "outcome: {'G': {'2010': 'ok', '2011': 'ok', '2012': 'ok', '2013': 'ok', '2014': 'ok', '2015': 'ok'}, 'N': {'2010': 'ok', '2011': 'ok', '2012': 'ok', '2013': 'ok', '2014': 'ok', '2015': 'ok'}, 'R': {'2010': 'ok', '2011': 'ok', '2012': 'ok', '2013': 'ok', '2014': 'ok', '2015': 'ok'}, 'R/G': {'2010': 'threshold; p-ratio; nk-rule; ', '2011': 'threshold; ', '2012': 'threshold; ', '2013': 'threshold; ', '2014': 'threshold; ', '2015': 'threshold; '}}\n",
@@ -1916,7 +1917,7 @@
       "2013        13557147.0  147937.796875   7202273.5  NaN\n",
       "2014        13748147.0  133198.250000   8277525.0  NaN\n",
       "2015        11133433.0  146572.187500  10812888.0  NaN]\n",
-      "timestamp: 2023-06-28T10:49:18.008201\n",
+      "timestamp: 2023-06-29T15:34:25.384828\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1924,7 +1925,7 @@
       "uid: output_2\n",
       "status: review\n",
       "type: table\n",
-      "properties: {'method': 'crosstab', 'negative': False, 'missing': True, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
+      "properties: {'method': 'crosstab', 'suppressed': True, 'negative': False, 'missing': True, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
       "command: safe_table = acro.crosstab(df.year, df.grant_type, values=missing, aggfunc=\"mean\")\n",
       "summary: review; missing values found\n",
       "outcome: {'G': {'2010': 'missing', '2011': '', '2012': '', '2013': '', '2014': '', '2015': 'missing'}, 'N': {'2010': 'missing', '2011': 'missing', '2012': '', '2013': 'missing', '2014': 'missing', '2015': 'missing'}, 'R': {'2010': 'missing', '2011': 'missing', '2012': 'missing', '2013': 'missing', '2014': 'missing', '2015': 'missing'}, 'R/G': {'2010': 'missing', '2011': '', '2012': '', '2013': '', '2014': '', '2015': ''}}\n",
@@ -1936,7 +1937,7 @@
       "2013        13557147.0  150488.453125   7088095.5  16765625.0\n",
       "2014        13748147.0  135494.781250   8118565.5  17845750.0\n",
       "2015        11133433.0  149143.625000  10596385.0  18278624.0]\n",
-      "timestamp: 2023-06-28T10:49:18.051118\n",
+      "timestamp: 2023-06-29T15:34:25.424749\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1944,7 +1945,7 @@
       "uid: output_3\n",
       "status: review\n",
       "type: table\n",
-      "properties: {'method': 'crosstab', 'negative': True, 'missing': False, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
+      "properties: {'method': 'crosstab', 'suppressed': True, 'negative': True, 'missing': False, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
       "command: safe_table = acro.crosstab(df.year, df.grant_type, values=negative, aggfunc=\"mean\")\n",
       "summary: review; negative values found\n",
       "outcome: {'G': {'2010': '', '2011': '', '2012': '', '2013': '', '2014': '', '2015': ''}, 'N': {'2010': '', '2011': 'negative', '2012': '', '2013': 'negative', '2014': 'negative', '2015': 'negative'}, 'R': {'2010': 'negative', '2011': 'negative', '2012': 'negative', '2013': 'negative', '2014': 'negative', '2015': 'negative'}, 'R/G': {'2010': '', '2011': '', '2012': '', '2013': '', '2014': '', '2015': ''}}\n",
@@ -1956,7 +1957,7 @@
       "2013        13557147.0  147937.625000   6988263.0  16765625.0\n",
       "2014        13748147.0  133198.078125   7997392.0  17845750.0\n",
       "2015        11133433.0  146572.015625  10388612.0  18278624.0]\n",
-      "timestamp: 2023-06-28T10:49:18.120735\n",
+      "timestamp: 2023-06-29T15:34:25.479671\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1964,7 +1965,7 @@
       "uid: output_4\n",
       "status: pass\n",
       "type: table\n",
-      "properties: {'method': 'pivot_table', 'negative': False, 'missing': False, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
+      "properties: {'method': 'pivot_table', 'suppressed': True, 'negative': False, 'missing': False, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
       "command: table = acro.pivot_table(\n",
       "summary: pass\n",
       "outcome: {\"('mean', 'inc_grants')\": {'G': 'ok', 'N': 'ok', 'R': 'ok', 'R/G': 'ok'}, \"('std', 'inc_grants')\": {'G': 'ok', 'N': 'ok', 'R': 'ok', 'R/G': 'ok'}}\n",
@@ -1975,7 +1976,7 @@
       "N           1.344319e+05  1.988737e+05\n",
       "R           8.098502e+06  3.204495e+07\n",
       "R/G         1.664827e+07  1.583532e+07]\n",
-      "timestamp: 2023-06-28T10:49:18.168040\n",
+      "timestamp: 2023-06-29T15:34:25.522216\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -1983,7 +1984,7 @@
       "uid: output_5\n",
       "status: review\n",
       "type: table\n",
-      "properties: {'method': 'pivot_table', 'negative': False, 'missing': True, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
+      "properties: {'method': 'pivot_table', 'suppressed': True, 'negative': False, 'missing': True, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
       "command: table = acro.pivot_table(\n",
       "summary: review; missing values found\n",
       "outcome: {\"('mean', 'inc_grants')\": {'G': 'missing', 'N': 'missing', 'R': 'missing', 'R/G': 'missing'}, \"('std', 'inc_grants')\": {'G': 'missing', 'N': 'missing', 'R': 'missing', 'R/G': 'missing'}}\n",
@@ -1994,7 +1995,7 @@
       "N           1.364700e+05  1.999335e+05\n",
       "R           8.006361e+06  3.228216e+07\n",
       "R/G         1.664827e+07  1.583532e+07]\n",
-      "timestamp: 2023-06-28T10:49:18.206900\n",
+      "timestamp: 2023-06-29T15:34:25.562861\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -2002,7 +2003,7 @@
       "uid: output_6\n",
       "status: review\n",
       "type: table\n",
-      "properties: {'method': 'pivot_table', 'negative': True, 'missing': False, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
+      "properties: {'method': 'pivot_table', 'suppressed': True, 'negative': True, 'missing': False, 'threshold': 0, 'p-ratio': 0, 'nk-rule': 0}\n",
       "command: table = acro.pivot_table(\n",
       "summary: review; negative values found\n",
       "outcome: {\"('mean', 'inc_grants')\": {'G': '', 'N': 'negative', 'R': 'negative', 'R/G': ''}, \"('std', 'inc_grants')\": {'G': '', 'N': 'negative', 'R': 'negative', 'R/G': ''}}\n",
@@ -2013,7 +2014,7 @@
       "N           1.341800e+05  1.990196e+05\n",
       "R           7.882230e+06  3.204558e+07\n",
       "R/G         1.664827e+07  1.583532e+07]\n",
-      "timestamp: 2023-06-28T10:49:18.256193\n",
+      "timestamp: 2023-06-29T15:34:25.612201\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -2029,8 +2030,8 @@
       "Dep. Variable:                                                     \n",
       "Model:                          OLS      Adj. R-squared:      0.893\n",
       "Method:               Least Squares         F-statistic:   2261.000\n",
-      "Date:              Wed, 28 Jun 2023  Prob (F-statistic):      0.000\n",
-      "Time:                      10:49:18      Log-Likelihood: -14495.000\n",
+      "Date:              Thu, 29 Jun 2023  Prob (F-statistic):      0.000\n",
+      "Time:                      15:34:25      Log-Likelihood: -14495.000\n",
       "No. Observations:               811                 AIC:  29000.000\n",
       "Df Residuals:                   807                 BIC:  29020.000\n",
       "Df Model:                         3                  NaN        NaN\n",
@@ -2043,7 +2044,7 @@
       "Prob(Omnibus):     0.000  Jarque-Bera (JB):  1.253318e+06\n",
       "Skew:              9.899          Prob(JB):  0.000000e+00\n",
       "Kurtosis:        194.566          Cond. No.  1.050000e+08]\n",
-      "timestamp: 2023-06-28T10:49:18.317809\n",
+      "timestamp: 2023-06-29T15:34:25.676673\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -2059,8 +2060,8 @@
       "Dep. Variable:                                                     \n",
       "Model:                          OLS      Adj. R-squared:      0.893\n",
       "Method:               Least Squares         F-statistic:   2261.000\n",
-      "Date:              Wed, 28 Jun 2023  Prob (F-statistic):      0.000\n",
-      "Time:                      10:49:18      Log-Likelihood: -14495.000\n",
+      "Date:              Thu, 29 Jun 2023  Prob (F-statistic):      0.000\n",
+      "Time:                      15:34:25      Log-Likelihood: -14495.000\n",
       "No. Observations:               811                 AIC:  29000.000\n",
       "Df Residuals:                   807                 BIC:  29020.000\n",
       "Df Model:                         3                  NaN        NaN\n",
@@ -2073,7 +2074,7 @@
       "Prob(Omnibus):     0.000  Jarque-Bera (JB):  1.253318e+06\n",
       "Skew:              9.899          Prob(JB):  0.000000e+00\n",
       "Kurtosis:        194.566          Cond. No.  1.050000e+08]\n",
-      "timestamp: 2023-06-28T10:49:18.344270\n",
+      "timestamp: 2023-06-29T15:34:25.705381\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -2089,8 +2090,8 @@
       "Dep. Variable:                                                    \n",
       "Model:                      Probit     Df Residuals:  8.060000e+02\n",
       "Method:                        MLE         Df Model:  4.000000e+00\n",
-      "Date:             Wed, 28 Jun 2023    Pseudo R-squ.:  2.140000e-01\n",
-      "Time:                     10:49:18   Log-Likelihood: -4.004600e+02\n",
+      "Date:             Thu, 29 Jun 2023    Pseudo R-squ.:  2.140000e-01\n",
+      "Time:                     15:34:25   Log-Likelihood: -4.004600e+02\n",
       "converged:                    True          LL-Null: -5.095000e+02\n",
       "Covariance Type:         nonrobust      LLR p-value:  4.875000e-46,                        coef       std err      z  P>|z|        [0.025  \\\n",
       "const          4.740000e-02  5.700000e-02  0.838  0.402 -6.300000e-02   \n",
@@ -2105,7 +2106,7 @@
       "inc_grants     1.620000e-07  \n",
       "inc_donations  3.300000e-07  \n",
       "total_costs   -1.440000e-08  ]\n",
-      "timestamp: 2023-06-28T10:49:18.369948\n",
+      "timestamp: 2023-06-29T15:34:25.736446\n",
       "comments: []\n",
       "\n",
       "\n",
@@ -2121,8 +2122,8 @@
       "Dep. Variable:                                                    \n",
       "Model:                       Logit     Df Residuals:  8.060000e+02\n",
       "Method:                        MLE         Df Model:  4.000000e+00\n",
-      "Date:             Wed, 28 Jun 2023    Pseudo R-squ.:  2.187000e-01\n",
-      "Time:                     10:49:18   Log-Likelihood: -3.980700e+02\n",
+      "Date:             Thu, 29 Jun 2023    Pseudo R-squ.:  2.187000e-01\n",
+      "Time:                     15:34:25   Log-Likelihood: -3.980700e+02\n",
       "converged:                    True          LL-Null: -5.095000e+02\n",
       "Covariance Type:         nonrobust      LLR p-value:  4.532000e-47,                        coef       std err      z  P>|z|        [0.025  \\\n",
       "const          5.120000e-02  9.100000e-02  0.561  0.575 -1.280000e-01   \n",
@@ -2137,7 +2138,7 @@
       "inc_grants     2.660000e-07  \n",
       "inc_donations  7.160000e-07  \n",
       "total_costs   -2.150000e-08  ]\n",
-      "timestamp: 2023-06-28T10:49:18.404033\n",
+      "timestamp: 2023-06-29T15:34:25.773254\n",
       "comments: []\n",
       "\n",
       "\n"
@@ -2166,8 +2167,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro::records:remove(): output_1 removed\n",
-      "INFO:acro::records:remove(): output_4 removed\n"
+      "INFO:acro:records:remove(): output_1 removed\n",
+      "INFO:acro:records:remove(): output_4 removed\n"
      ]
     }
    ],
@@ -2194,7 +2195,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro::records:rename_output(): output_2 renamed to pivot_table\n"
+      "INFO:acro:records:rename_output(): output_2 renamed to pivot_table\n"
      ]
     }
    ],
@@ -2220,8 +2221,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro::records:a comment was added to output_0\n",
-      "INFO:acro::records:a comment was added to output_0\n"
+      "INFO:acro:records:a comment was added to output_0\n",
+      "INFO:acro:records:a comment was added to output_0\n"
      ]
     }
    ],
@@ -2270,7 +2271,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro::records:outputs written to: ACRO_RES\n"
+      "INFO:acro:records:outputs written to: ACRO_RES\n"
      ]
     }
    ],
@@ -2354,6 +2355,7 @@
       "        \"type\": \"table\",\n",
       "        \"properties\": {\n",
       "            \"method\": \"crosstab\",\n",
+      "            \"suppressed\": true,\n",
       "            \"negative\": false,\n",
       "            \"missing\": false,\n",
       "            \"threshold\": 6,\n",
@@ -2399,7 +2401,7 @@
       "        \"output\": [\n",
       "            \"output_0_0.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:17.966635\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.343673\",\n",
       "        \"comments\": [\n",
       "            \"This is a cross table between year and grant_type\",\n",
       "            \"6 cells were supressed in this table\"\n",
@@ -2411,6 +2413,7 @@
       "        \"type\": \"table\",\n",
       "        \"properties\": {\n",
       "            \"method\": \"crosstab\",\n",
+      "            \"suppressed\": true,\n",
       "            \"negative\": true,\n",
       "            \"missing\": false,\n",
       "            \"threshold\": 0,\n",
@@ -2456,7 +2459,7 @@
       "        \"output\": [\n",
       "            \"output_3_0.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.120735\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.479671\",\n",
       "        \"comments\": []\n",
       "    },\n",
       "    \"output_5\": {\n",
@@ -2465,6 +2468,7 @@
       "        \"type\": \"table\",\n",
       "        \"properties\": {\n",
       "            \"method\": \"pivot_table\",\n",
+      "            \"suppressed\": true,\n",
       "            \"negative\": false,\n",
       "            \"missing\": true,\n",
       "            \"threshold\": 0,\n",
@@ -2490,7 +2494,7 @@
       "        \"output\": [\n",
       "            \"output_5_0.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.206900\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.562861\",\n",
       "        \"comments\": []\n",
       "    },\n",
       "    \"output_6\": {\n",
@@ -2499,6 +2503,7 @@
       "        \"type\": \"table\",\n",
       "        \"properties\": {\n",
       "            \"method\": \"pivot_table\",\n",
+      "            \"suppressed\": true,\n",
       "            \"negative\": true,\n",
       "            \"missing\": false,\n",
       "            \"threshold\": 0,\n",
@@ -2524,7 +2529,7 @@
       "        \"output\": [\n",
       "            \"output_6_0.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.256193\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.612201\",\n",
       "        \"comments\": []\n",
       "    },\n",
       "    \"output_7\": {\n",
@@ -2543,7 +2548,7 @@
       "            \"output_7_1.csv\",\n",
       "            \"output_7_2.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.317809\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.676673\",\n",
       "        \"comments\": []\n",
       "    },\n",
       "    \"output_8\": {\n",
@@ -2562,7 +2567,7 @@
       "            \"output_8_1.csv\",\n",
       "            \"output_8_2.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.344270\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.705381\",\n",
       "        \"comments\": []\n",
       "    },\n",
       "    \"output_9\": {\n",
@@ -2580,7 +2585,7 @@
       "            \"output_9_0.csv\",\n",
       "            \"output_9_1.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.369948\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.736446\",\n",
       "        \"comments\": []\n",
       "    },\n",
       "    \"output_10\": {\n",
@@ -2598,7 +2603,7 @@
       "            \"output_10_0.csv\",\n",
       "            \"output_10_1.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.404033\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.773254\",\n",
       "        \"comments\": []\n",
       "    },\n",
       "    \"pivot_table\": {\n",
@@ -2607,6 +2612,7 @@
       "        \"type\": \"table\",\n",
       "        \"properties\": {\n",
       "            \"method\": \"crosstab\",\n",
+      "            \"suppressed\": true,\n",
       "            \"negative\": false,\n",
       "            \"missing\": true,\n",
       "            \"threshold\": 0,\n",
@@ -2652,7 +2658,7 @@
       "        \"output\": [\n",
       "            \"pivot_table_0.csv\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.051118\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.424749\",\n",
       "        \"comments\": []\n",
       "    },\n",
       "    \"output_11\": {\n",
@@ -2666,7 +2672,7 @@
       "        \"output\": [\n",
       "            \"XandY.jfif\"\n",
       "        ],\n",
-      "        \"timestamp\": \"2023-06-28T10:49:18.491107\",\n",
+      "        \"timestamp\": \"2023-06-29T15:34:25.874530\",\n",
       "        \"comments\": [\n",
       "            \"This output is an image showing the relationship between X and Y\"\n",
       "        ]\n",

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -32,7 +32,7 @@ def test_crosstab_without_suppression(data):
     acro = ACRO(suppress=False)
     _ = acro.crosstab(data.year, data.grant_type)
     output = acro.results.get_index(0)
-    correct_summary: str = "fail; threshold: 6 cells suppressed; "
+    correct_summary: str = "fail; threshold: 6 cells may need suppressing; "
     assert output.summary == correct_summary
     assert 48 == output.output[0]["R/G"].sum()
 

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -24,12 +24,25 @@ def data() -> pd.DataFrame:
 @pytest.fixture
 def acro() -> ACRO:
     """Initialise ACRO."""
-    return ACRO()
+    return ACRO(suppress=True)
+
+
+def test_crosstab_without_suppression(data):
+    """Crosstab threshold without automatic suppression."""
+    acro = ACRO(suppress=False)
+    _ = acro.crosstab(data.year, data.grant_type)
+    output = acro.results.get_index(0)
+    correct_summary: str = "fail; threshold: 6 cells suppressed; "
+    assert output.summary == correct_summary
+    assert 48 == output.output[0]["R/G"].sum()
 
 
 def test_crosstab_threshold(data, acro):
     """Crosstab threshold test."""
     _ = acro.crosstab(data.year, data.grant_type)
+    output = acro.results.get_index(0)
+    total_nan: int = output.output[0]["R/G"].isnull().sum()
+    assert total_nan == 6
     results: Records = acro.finalise()
     correct_summary: str = "fail; threshold: 6 cells suppressed; "
     output = results.get_index(0)
@@ -65,6 +78,17 @@ def test_negatives(data, acro):
     output_1 = results.get_index(1)
     assert output_0.summary == correct_summary
     assert output_1.summary == correct_summary
+
+
+def test_pivot_table_without_suppression(data):
+    """Pivot table without automatic suppression."""
+    acro = ACRO(suppress=False)
+    _ = acro.pivot_table(
+        data, index=["grant_type"], values=["inc_grants"], aggfunc=["mean", "std"]
+    )
+    output_0 = acro.results.get_index(0)
+    assert 36293992.0 == output_0.output[0]["mean"]["inc_grants"].sum()
+    assert "pass" == output_0.summary
 
 
 def test_pivot_table_pass(data, acro):


### PR DESCRIPTION
Resolves #82 

Added `suppress: bool` argument to the `ACRO` constructor, which defaults to `False`.

For `crosstab()` and `pivot_table()` a new Boolean field `"suppressed"` is added to the `properties` dictionary to indicate whether the output table (csv in JSON) has been suppressed.