### PR TITLE
write sdc params to config.json upon finalise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 *    Add writing sha256 checksums upon finalise ([#107](https://github.com/AI-SDC/ACRO/pull/107))
 *    Refactor load_json Records class function to static load_results ([#109](https://github.com/AI-SDC/ACRO/pull/109))
+*    Write SDC parameters to config.json upon finalise ([#110](https://github.com/AI-SDC/ACRO/pull/110))
 
 ## Version 0.3.0 (Jul 04, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 Changes:
 *    Add writing sha256 checksums upon finalise ([#107](https://github.com/AI-SDC/ACRO/pull/107))
-*    Refactor load_json Records class function to static load_results ([#109](https://github.com/AI-SDC/ACRO/pull/109))
-*    Write SDC parameters to config.json upon finalise ([#110](https://github.com/AI-SDC/ACRO/pull/110))
+*    Refactor load_json Records class function to static load_results ([#110](https://github.com/AI-SDC/ACRO/pull/110))
+*    Write SDC parameters to config.json upon finalise ([#111](https://github.com/AI-SDC/ACRO/pull/111))
 
 ## Version 0.3.0 (Jul 04, 2023)
 

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -1,6 +1,8 @@
 """ACRO: Automatic Checking of Research Outputs."""
 
+import json
 import logging
+import os
 import pathlib
 import warnings
 from collections.abc import Callable
@@ -85,6 +87,9 @@ class ACRO:
             Object storing the outputs.
         """
         self.results.finalise(path, ext)
+        config_filename: str = os.path.normpath(f"{path}/config.json")
+        with open(config_filename, "w", newline="", encoding="utf-8") as file:
+            json.dump(self.config, file, indent=4, sort_keys=False)
         return self.results
 
     def remove_output(self, key: str) -> None:


### PR DESCRIPTION
Resolves #108 

Upon `finalise()` the parameters used for SDC checking are written to `config.json` - keeping it separate from the `results.json` seems cleaner.

Example `config.json`

```json
{
    "safe_threshold": 10,
    "safe_dof_threshold": 10,
    "safe_nk_n": 2,
    "safe_nk_k": 0.9,
    "safe_pratio_p": 0.1,
    "check_missing_values": false
}
```