### PR TITLE
add backward support for python38

### DIFF
--- a/acro/acro.py
+++ b/acro/acro.py
@@ -1,5 +1,7 @@
 """ACRO: Automatic Checking of Research Outputs."""
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/acro/record.py
+++ b/acro/record.py
@@ -1,5 +1,7 @@
 """ACRO: Output storage and serialization."""
 
+from __future__ import annotations
+
 import datetime
 import hashlib
 import json

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -1,5 +1,7 @@
 """ACRO: Utility Functions."""
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
 from inspect import FrameInfo, getframeinfo

--- a/acro/version.py
+++ b/acro/version.py
@@ -1,2 +1,2 @@
 """ACRO version number."""
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="acro",
-    version="0.4.2",
+    version="0.4.3",
     license="MIT",
     maintainer="Jim Smith",
     maintainer_email="james.smith@uwe.ac.uk",
@@ -18,8 +18,9 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/AI-SDC/ACRO",
     packages=find_packages(),
+    setup_requires=["wheel"],
     package_data={"acro": ["default.yaml"]},
-    python_requires=">=3.10",
+    python_requires=">=3.8",
     install_requires=["lxml", "numpy", "openpyxl", "pandas", "PyYAML", "statsmodels"],
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -27,8 +28,11 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Enables installation on Python 3.8 and 3.9.