### PR TITLE
fixing suppression when margins is true

### DIFF
--- a/acro/acro_stata_parser.py
+++ b/acro/acro_stata_parser.py
@@ -4,6 +4,8 @@ Jim Smith 2023 @james.smith@uwe.ac.uk
 MIT licenses apply.
 """
 
+import re
+
 import pandas as pd
 import statsmodels.iolib.summary as sm_iolib_summary
 
@@ -111,8 +113,21 @@ def parse_table_details(varlist: list, varnames: list, options: str) -> dict:
     >> table rowvar [colvar [supercolvar] [if] [in] [weight] [, options].
     """
     details: dict = {"errmsg": "", "rowvars": list([]), "colvars": list([])}
-    details["rowvars"] = [varlist.pop(0)]
-    details["colvars"] = list(reversed(varlist))
+    #details["rowvars"] = [varlist.pop(0)]
+    #details["colvars"] = list(reversed(varlist))
+
+    details["rowvars"] = varlist.pop(0).split()
+    details["colvars"] = varlist.pop(0).split()
+    if len(details["rowvars"])==0 or len(details["colvars"])==0:
+        details["errmsg"] = "To calculate cross tabulation, you need to provide at least one row and one column."
+        return details
+    #print(details["rowvars"])
+    #print(details["colvars"])
+    if varlist:
+        details["tables"] = varlist.pop(0).split()
+        #print(f"table is {details['tables']}")
+
+
     # by() contents are super-rows
     found, superrows = find_brace_contents("by", options)
     if found and len(superrows) > 0:
@@ -172,8 +187,12 @@ def parse_and_run(  # pylint: disable=too-many-arguments,too-many-locals
     # Sometime_TODO de-abbreviate according to
     # https://www.stata.com/manuals13/u11.pdf#u11.1.3ifexp
 
-    varlist: list = varlist_as_str.split()
-    # print(f' split varlist is {varlist}')
+    #varlist: list = varlist_as_str.split()
+
+    vars_within_parentheses = re.findall(r'\((.*?)\)', varlist_as_str) # (year survivor) grant_type ---->  ["year survivor", "grant_type"]
+    vars_outside_parentheses = re.findall(r'\b(?![^(]*\))\w+\b', varlist_as_str)
+    varlist = vars_within_parentheses + vars_outside_parentheses
+    print(f' split varlist is {varlist}')
 
     # data reduction
     # print(f'before in {mydata.shape}')
@@ -287,64 +306,88 @@ def run_table_command(  # pylint: disable=too-many-arguments,too-many-locals
         return details["errmsg"]
 
     aggfuncs = list(map(lambda x: x.replace("sd", "std"), details["aggfuncs"]))
-    rows, cols = [], []
     # don't pass single aggfunc as a list
     if len(aggfuncs) == 1:
         aggfuncs = aggfuncs[0]
 
-    for row in details["rowvars"]:
-        rows.append(data[row])
-    for col in details["colvars"]:
-        cols.append(data[col])
-    if len(aggfuncs) > 0 and len(details["values"]) > 0:
-        # sanity checking
-        # if len(rows) > 1 or len(cols) > 1:
-        #     msg = (
-        #         "acro crosstab with an aggregation function "
-        #         " does not currently support hierarchies within rows or columns"
-        #     )
-        #     return msg
+    set_of_data = [data]
 
-        if len(details["values"]) > 1:
-            msg = (
-                "pandas crosstab can  aggregate over multiple functions "
-                "but only over one feature/attribute: provided as 'value'"
+    # if tables var parameter was assigned, each table will be treated as an exlcion which will be applied to the data.
+    # The number of datasets will be equal to the numebr of unique values in the tables var
+    # Crosstabulation will be calculate for each dataset
+    if "tables" in details:
+            #print(f"table is {details['tables']}")
+            for table in details['tables']:
+                unique_values = data[table].unique()
+                #print(f"unique_values are {unique_values}")
+                for value in unique_values:
+                    exclusion = f"{table}=='{value}'"
+                    #print(f"exclusion is {exclusion}")
+                    my_data = apply_stata_ifstmt(exclusion, data)
+                    set_of_data.insert(0,my_data)
+    #print(f"set of data is {set_of_data}")
+
+    for my_data in set_of_data:
+        rows, cols = [], []
+        #print(f"my data is {my_data}")
+        for row in details["rowvars"]:
+            rows.append(my_data[row])
+        for col in details["colvars"]:
+            cols.append(my_data[col])
+        #print(f"rows are {rows}")
+        #print(f"cols are {cols}")
+        if len(aggfuncs) > 0 and len(details["values"]) > 0:
+            # sanity checking
+            # if len(rows) > 1 or len(cols) > 1:
+            #     msg = (
+            #         "acro crosstab with an aggregation function "
+            #         " does not currently support hierarchies within rows or columns"
+            #     )
+            #     return msg
+
+            if len(details["values"]) > 1:
+                msg = (
+                    "pandas crosstab can  aggregate over multiple functions "
+                    "but only over one feature/attribute: provided as 'value'"
+                )
+                return msg
+            val = details["values"][0]
+            values = data[val]
+            safe_output = stata_config.stata_acro.crosstab(
+                index=rows,
+                columns=cols,
+                aggfunc=aggfuncs,
+                values=values,
+                margins=details["totals"],
+                margins_name="Total",
             )
-            return msg
-        val = details["values"][0]
-        values = data[val]
 
-        safe_output = stata_config.stata_acro.crosstab(
-            index=rows,
-            columns=cols,
-            aggfunc=aggfuncs,
-            values=values,
-            margins=details["totals"],
-            margins_name="Total",
-        )
-
-    else:
-        safe_output = stata_config.stata_acro.crosstab(
-            index=rows,
-            columns=cols,
-            # suppress=details['suppress'],
-            margins=details["totals"],
-            margins_name="Total",
-        )
-    options_str = ""
-    formatting = [
-        "cellwidth",
-        "csepwidth",
-        "stubwidth",
-        "scsepwidth",
-        "center",
-        "left",
-    ]
-    if any(word in options for word in formatting):
-        options_str = "acro does not currently support table formatting commands.\n "
-    return options_str + prettify_table_string(safe_output) + "\n"
-
-
+        else:
+            safe_output = stata_config.stata_acro.crosstab(
+                index=rows,
+                columns=cols,
+                # suppress=details['suppress'],
+                margins=details["totals"],
+                margins_name="Total",
+            
+             )
+        options_str = ""
+        formatting = [
+            "cellwidth",
+            "csepwidth",
+            "stubwidth",
+            "scsepwidth",
+            "center",
+            "left",
+        ]
+        if any(word in options for word in formatting):
+            options_str = "acro does not currently support table formatting commands.\n "
+        print(prettify_table_string(safe_output))
+        #results = []
+        #results.append(prettify_table_string(safe_output))
+    #return options_str + prettify_table_string(safe_output) + "\n"
+    #return results
+            
 def run_regression(command: str, data: pd.DataFrame, varlist: list) -> str:
     """Interprets and runs appropriate regression command."""
     # get components of formula

--- a/acro/acro_stata_parser.py
+++ b/acro/acro_stata_parser.py
@@ -4,8 +4,6 @@ Jim Smith 2023 @james.smith@uwe.ac.uk
 MIT licenses apply.
 """
 
-import re
-
 import pandas as pd
 import statsmodels.iolib.summary as sm_iolib_summary
 
@@ -113,22 +111,8 @@ def parse_table_details(varlist: list, varnames: list, options: str) -> dict:
     >> table rowvar [colvar [supercolvar] [if] [in] [weight] [, options].
     """
     details: dict = {"errmsg": "", "rowvars": list([]), "colvars": list([])}
-    # details["rowvars"] = [varlist.pop(0)]
-    # details["colvars"] = list(reversed(varlist))
-
-    details["rowvars"] = varlist.pop(0).split()
-    details["colvars"] = varlist.pop(0).split()
-    if len(details["rowvars"]) == 0 or len(details["colvars"]) == 0:
-        details["errmsg"] = (
-            "To calculate cross tabulation, you need to provide at least one row and one column."
-        )
-        return details
-    # print(details["rowvars"])
-    # print(details["colvars"])
-    if varlist:
-        details["tables"] = varlist.pop(0).split()
-        # print(f"table is {details['tables']}")
-
+    details["rowvars"] = [varlist.pop(0)]
+    details["colvars"] = list(reversed(varlist))
     # by() contents are super-rows
     found, superrows = find_brace_contents("by", options)
     if found and len(superrows) > 0:
@@ -188,14 +172,8 @@ def parse_and_run(  # pylint: disable=too-many-arguments,too-many-locals
     # Sometime_TODO de-abbreviate according to
     # https://www.stata.com/manuals13/u11.pdf#u11.1.3ifexp
 
-    # varlist: list = varlist_as_str.split()
-
-    vars_within_parentheses = re.findall(
-        r"\((.*?)\)", varlist_as_str
-    )  # (year survivor) grant_type ---->  ["year survivor", "grant_type"]
-    vars_outside_parentheses = re.findall(r"\b(?![^(]*\))\w+\b", varlist_as_str)
-    varlist = vars_within_parentheses + vars_outside_parentheses
-    print(f" split varlist is {varlist}")
+    varlist: list = varlist_as_str.split()
+    # print(f' split varlist is {varlist}')
 
     # data reduction
     # print(f'before in {mydata.shape}')
@@ -309,88 +287,62 @@ def run_table_command(  # pylint: disable=too-many-arguments,too-many-locals
         return details["errmsg"]
 
     aggfuncs = list(map(lambda x: x.replace("sd", "std"), details["aggfuncs"]))
+    rows, cols = [], []
     # don't pass single aggfunc as a list
     if len(aggfuncs) == 1:
         aggfuncs = aggfuncs[0]
 
-    set_of_data = [data]
+    for row in details["rowvars"]:
+        rows.append(data[row])
+    for col in details["colvars"]:
+        cols.append(data[col])
+    if len(aggfuncs) > 0 and len(details["values"]) > 0:
+        # sanity checking
+        # if len(rows) > 1 or len(cols) > 1:
+        #     msg = (
+        #         "acro crosstab with an aggregation function "
+        #         " does not currently support hierarchies within rows or columns"
+        #     )
+        #     return msg
 
-    # if tables var parameter was assigned, each table will be treated as an exlcion which will be applied to the data.
-    # The number of datasets will be equal to the number of unique values in the tables var
-    # Crosstabulation will be calculate for each dataset
-    if "tables" in details:
-        # print(f"table is {details['tables']}")
-        for table in details["tables"]:
-            unique_values = data[table].unique()
-            # print(f"unique_values are {unique_values}")
-            for value in unique_values:
-                exclusion = f"{table}=='{value}'"
-                # print(f"exclusion is {exclusion}")
-                my_data = apply_stata_ifstmt(exclusion, data)
-                set_of_data.insert(0, my_data)
-    # print(f"set of data is {set_of_data}")
-
-    for my_data in set_of_data:
-        rows, cols = [], []
-        # print(f"my data is {my_data}")
-        for row in details["rowvars"]:
-            rows.append(my_data[row])
-        for col in details["colvars"]:
-            cols.append(my_data[col])
-        # print(f"rows are {rows}")
-        # print(f"cols are {cols}")
-        if len(aggfuncs) > 0 and len(details["values"]) > 0:
-            # sanity checking
-            # if len(rows) > 1 or len(cols) > 1:
-            #     msg = (
-            #         "acro crosstab with an aggregation function "
-            #         " does not currently support hierarchies within rows or columns"
-            #     )
-            #     return msg
-
-            if len(details["values"]) > 1:
-                msg = (
-                    "pandas crosstab can  aggregate over multiple functions "
-                    "but only over one feature/attribute: provided as 'value'"
-                )
-                return msg
-            val = details["values"][0]
-            values = data[val]
-            safe_output = stata_config.stata_acro.crosstab(
-                index=rows,
-                columns=cols,
-                aggfunc=aggfuncs,
-                values=values,
-                margins=details["totals"],
-                margins_name="Total",
+        if len(details["values"]) > 1:
+            msg = (
+                "pandas crosstab can  aggregate over multiple functions "
+                "but only over one feature/attribute: provided as 'value'"
             )
+            return msg
+        val = details["values"][0]
+        values = data[val]
 
-        else:
-            safe_output = stata_config.stata_acro.crosstab(
-                index=rows,
-                columns=cols,
-                # suppress=details['suppress'],
-                margins=details["totals"],
-                margins_name="Total",
-            )
-        options_str = ""
-        formatting = [
-            "cellwidth",
-            "csepwidth",
-            "stubwidth",
-            "scsepwidth",
-            "center",
-            "left",
-        ]
-        if any(word in options for word in formatting):
-            options_str = (
-                "acro does not currently support table formatting commands.\n "
-            )
-        print(prettify_table_string(safe_output))
-        # results = []
-        # results.append(prettify_table_string(safe_output))
-    # return options_str + prettify_table_string(safe_output) + "\n"
-    # return results
+        safe_output = stata_config.stata_acro.crosstab(
+            index=rows,
+            columns=cols,
+            aggfunc=aggfuncs,
+            values=values,
+            margins=details["totals"],
+            margins_name="Total",
+        )
+
+    else:
+        safe_output = stata_config.stata_acro.crosstab(
+            index=rows,
+            columns=cols,
+            # suppress=details['suppress'],
+            margins=details["totals"],
+            margins_name="Total",
+        )
+    options_str = ""
+    formatting = [
+        "cellwidth",
+        "csepwidth",
+        "stubwidth",
+        "scsepwidth",
+        "center",
+        "left",
+    ]
+    if any(word in options for word in formatting):
+        options_str = "acro does not currently support table formatting commands.\n "
+    return options_str + prettify_table_string(safe_output) + "\n"
 
 
 def run_regression(command: str, data: pd.DataFrame, varlist: list) -> str:

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -1500,6 +1500,28 @@ def crosstab_with_totals(  # pylint: disable=too-many-arguments,too-many-locals
                 dropna=dropna,
                 normalize=normalize,
             )
+
+            table, _ = delete_empty_rows_columns(table)
+            masks = create_crosstab_masks(
+                index_new,
+                columns_new,
+                values,
+                rownames,
+                colnames,
+                aggfunc,
+                margins,
+                margins_name,
+                dropna,
+                normalize,
+            )
+
+            # Force the apply_suppression not to display the outcome dataframe
+            previous_level = logger.getEffectiveLevel()
+            logger.setLevel(logging.WARNING)
+            # apply the suppression
+            table, _ = apply_suppression(table, masks)
+            logger.setLevel(previous_level)
+
         else:
             table = pd.pivot_table(  # type: ignore
                 data=data,

--- a/notebooks/test-nursery.ipynb
+++ b/notebooks/test-nursery.ipynb
@@ -18,7 +18,7 @@
    "id": "e33fd4fb",
    "metadata": {
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "slide"
     }
    },
    "outputs": [],
@@ -86,8 +86,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:version: 0.4.3\n",
-      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False, 'survival_safe_threshold': 10, 'zeros_are_disclosive': True}\n",
+      "INFO:acro:version: 0.4.5\n",
+      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False, 'survival_safe_threshold': 10, 'zeros_are_disclosive': True, 'unsupported_filetypes': ['.gph', '.svg']}\n",
       "INFO:acro:automatic suppression: True\n"
      ]
     }
@@ -410,16 +410,16 @@
      "text": [
       "INFO:acro:get_summary(): fail; threshold: 4 cells suppressed; \n",
       "INFO:acro:outcome_df:\n",
-      "--------------------------------------------------------|\n",
-      "parents        |great_pret   |pretentious  |usual       |\n",
-      "recommendation |             |             |            |\n",
-      "--------------------------------------------------------|\n",
-      "not_recom      |          ok |          ok |          ok|\n",
-      "priority       |          ok |          ok |          ok|\n",
-      "recommend      | threshold;  | threshold;  | threshold; |\n",
-      "spec_prior     |          ok |          ok |          ok|\n",
-      "very_recom     | threshold;  |          ok |          ok|\n",
-      "--------------------------------------------------------|\n",
+      "----------------------------------------------------|\n",
+      "parents    |great_pret   |pretentious  |usual       |\n",
+      "recommend  |             |             |            |\n",
+      "----------------------------------------------------|\n",
+      "not_recom  |          ok |          ok |          ok|\n",
+      "priority   |          ok |          ok |          ok|\n",
+      "recommend  | threshold;  | threshold;  | threshold; |\n",
+      "spec_prior |          ok |          ok |          ok|\n",
+      "very_recom | threshold;  |          ok |          ok|\n",
+      "----------------------------------------------------|\n",
       "\n",
       "INFO:acro:records:add(): output_0\n"
      ]
@@ -428,20 +428,78 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "parents         great_pret  pretentious   usual\n",
-      "recommendation                                 \n",
-      "not_recom           1440.0       1440.0  1440.0\n",
-      "priority             858.0       1484.0  1924.0\n",
-      "recommend              NaN          NaN     NaN\n",
-      "spec_prior          2022.0       1264.0   758.0\n",
-      "very_recom             NaN        132.0   196.0\n"
+      "parents     great_pret  pretentious   usual\n",
+      "recommend                                  \n",
+      "not_recom       1440.0       1440.0  1440.0\n",
+      "priority         858.0       1484.0  1924.0\n",
+      "recommend          NaN          NaN     NaN\n",
+      "spec_prior      2022.0       1264.0   758.0\n",
+      "very_recom         NaN        132.0   196.0\n"
      ]
     }
    ],
    "source": [
     "safe_table = acro.crosstab(\n",
-    "    df.recommend, df.parents, rownames=[\"recommendation\"], colnames=[\"parents\"]\n",
+    "    df.recommend,\n",
+    "    df.parents,\n",
     ")\n",
+    "print(safe_table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3d09450",
+   "metadata": {},
+   "source": [
+    "### ACRO crosstab with totals\n",
+    "This is an example of crosstab with totals columns and suppression.  \n",
+    "Note that when margins is true any row or column where all the cells are discolsive is deleted. If you wish to see such row or column set show_suppressed to True.  \n",
+    "show_suppressed parameter does not work with herichical tables and when the aggregation function is the standard deviation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "42825f24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:acro:get_summary(): fail; threshold: 5 cells suppressed; \n",
+      "INFO:acro:outcome_df:\n",
+      "------------------------------------------------------------------|\n",
+      "parents    |great_pret   |pretentious  |usual        |All         |\n",
+      "recommend  |             |             |             |            |\n",
+      "------------------------------------------------------------------|\n",
+      "not_recom  |          ok |          ok |          ok |          ok|\n",
+      "priority   |          ok |          ok |          ok |          ok|\n",
+      "recommend  | threshold;  | threshold;  | threshold;  | threshold; |\n",
+      "spec_prior |          ok |          ok |          ok |          ok|\n",
+      "very_recom | threshold;  |          ok |          ok |          ok|\n",
+      "All        |          ok |          ok |          ok |          ok|\n",
+      "------------------------------------------------------------------|\n",
+      "\n",
+      "INFO:acro:records:add(): output_1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "parents     great_pret  pretentious  usual    All\n",
+      "recommend                                        \n",
+      "not_recom       1440.0         1440   1440   4320\n",
+      "priority         858.0         1484   1924   4266\n",
+      "spec_prior      2022.0         1264    758   4044\n",
+      "very_recom         NaN          132    196    328\n",
+      "All             4320.0         4320   4318  12958\n"
+     ]
+    }
+   ],
+   "source": [
+    "safe_table = acro.crosstab(df.recommend, df.parents, margins=True)\n",
     "print(safe_table)"
    ]
   },
@@ -458,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "27329e57",
    "metadata": {},
    "outputs": [
@@ -479,7 +537,7 @@
       "very_recom | threshold;  |          ok |          ok|\n",
       "----------------------------------------------------|\n",
       "\n",
-      "INFO:acro:records:add(): output_1\n"
+      "INFO:acro:records:add(): output_2\n"
      ]
     },
     {
@@ -505,7 +563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "ed5134ab",
    "metadata": {},
    "outputs": [],
@@ -527,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "298d2b40",
    "metadata": {
     "slideshow": {
@@ -552,25 +610,76 @@
       "very_recom | p-ratio; nk-rule;  |                 ok |                            ok|\n",
       "------------------------------------------------------------------------------------|\n",
       "\n",
-      "INFO:acro:records:add(): output_2\n"
+      "INFO:acro:records:add(): output_3\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "parents     great_pret  pretentious     usual\n",
-      "recommend                                    \n",
-      "not_recom     3.147222     3.097917  3.093750\n",
-      "priority      2.636364     3.000674  3.075364\n",
-      "recommend          NaN          NaN       NaN\n",
-      "spec_prior    3.345697     3.332278  3.317942\n",
-      "very_recom         NaN     2.227273  2.229592\n"
+      "parents     great_pret  pretentious   usual\n",
+      "recommend                                  \n",
+      "not_recom       1440.0       1440.0  1440.0\n",
+      "priority         858.0       1484.0  1924.0\n",
+      "recommend          NaN          NaN     NaN\n",
+      "spec_prior      2022.0       1264.0   758.0\n",
+      "very_recom         NaN        132.0   196.0\n"
      ]
     }
    ],
    "source": [
-    "safe_table = acro.crosstab(df.recommend, df.parents, values=df.children, aggfunc=\"mean\")\n",
+    "safe_table = acro.crosstab(\n",
+    "    df.recommend, df.parents, values=df.children, aggfunc=\"count\"\n",
+    ")\n",
+    "print(safe_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b4aea046",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:acro:get_summary(): fail; threshold: 2 cells suppressed; p-ratio: 8 cells suppressed; nk-rule: 8 cells suppressed; \n",
+      "INFO:acro:outcome_df:\n",
+      "---------------------------------------------------------------------------------------------------------------------------------------------------------|\n",
+      "           mode_aggfunc                                                           |mean                                                                  |\n",
+      "parents    great_pret          pretentious         usual                          |great_pret          pretentious         usual                         |\n",
+      "recommend                                                                         |                                                                      |\n",
+      "---------------------------------------------------------------------------------------------------------------------------------------------------------|\n",
+      "not_recom                   ok                  ok                             ok |                 ok                  ok                             ok|\n",
+      "priority                    ok                  ok                             ok |                 ok                  ok                             ok|\n",
+      "recommend   p-ratio; nk-rule;   p-ratio; nk-rule;   threshold; p-ratio; nk-rule;  | p-ratio; nk-rule;   p-ratio; nk-rule;   threshold; p-ratio; nk-rule; |\n",
+      "spec_prior                  ok                  ok                             ok |                 ok                  ok                             ok|\n",
+      "very_recom  p-ratio; nk-rule;                   ok                             ok | p-ratio; nk-rule;                   ok                             ok|\n",
+      "---------------------------------------------------------------------------------------------------------------------------------------------------------|\n",
+      "\n",
+      "INFO:acro:records:add(): output_4\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           mode_aggfunc                         mean                      \n",
+      "parents      great_pret pretentious usual great_pret pretentious     usual\n",
+      "recommend                                                                 \n",
+      "not_recom           3.0         2.0   1.0   3.100694    3.143750  3.111806\n",
+      "priority            1.0         1.0   1.0   2.627040    3.022237  3.120062\n",
+      "recommend           NaN         NaN   NaN        NaN         NaN       NaN\n",
+      "spec_prior          3.0         3.0   3.0   3.307122    3.336234  3.323219\n",
+      "very_recom          NaN         1.0   1.0        NaN    2.227273  2.178571\n"
+     ]
+    }
+   ],
+   "source": [
+    "safe_table = acro.crosstab(\n",
+    "    df.recommend, df.parents, values=df.children, aggfunc=[\"mode\", \"mean\"]\n",
+    ")\n",
     "print(safe_table)"
    ]
   },
@@ -592,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "966c1a9b",
    "metadata": {
     "slideshow": {
@@ -616,7 +725,7 @@
       "usual        ok      | ok     |\n",
       "------------------------------|\n",
       "\n",
-      "INFO:acro:records:add(): output_3\n"
+      "INFO:acro:records:add(): output_5\n"
      ]
     },
     {
@@ -626,9 +735,9 @@
       "                 mean       std\n",
       "             children  children\n",
       "parents                        \n",
-      "great_pret   3.138657  2.257859\n",
-      "pretentious  3.106481  2.216308\n",
-      "usual        3.084722  2.175608\n"
+      "great_pret   3.103241  2.213116\n",
+      "pretentious  3.130324  2.250447\n",
+      "usual        3.109259  2.216799\n"
      ]
     }
    ],
@@ -637,6 +746,62 @@
     "    df, index=[\"parents\"], values=[\"children\"], aggfunc=[\"mean\", \"std\"]\n",
     ")\n",
     "print(table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4adc374b",
+   "metadata": {},
+   "source": [
+    "### ACRO pivot_table with margins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "9c024b65",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:acro:get_summary(): fail; threshold: 5 cells suppressed; p-ratio: 5 cells suppressed; nk-rule: 5 cells suppressed; \n",
+      "INFO:acro:outcome_df:\n",
+      "-----------------------------------------------------------------------------------------------------------|\n",
+      "            children                                                                                       |\n",
+      "recommend   not_recom priority recommend                      spec_prior very_recom                     All|\n",
+      "parents                                                                                                    |\n",
+      "-----------------------------------------------------------------------------------------------------------|\n",
+      "great_pret   ok        ok       threshold; p-ratio; nk-rule;   ok         threshold; p-ratio; nk-rule;   ok|\n",
+      "pretentious  ok        ok       threshold; p-ratio; nk-rule;   ok                                    ok  ok|\n",
+      "usual        ok        ok       threshold; p-ratio; nk-rule;   ok                                    ok  ok|\n",
+      "All          ok        ok       threshold; p-ratio; nk-rule;   ok                                    ok  ok|\n",
+      "-----------------------------------------------------------------------------------------------------------|\n",
+      "\n",
+      "INFO:acro:Disclosive cells were deleted from the dataframe before calculating the pivot table\n",
+      "INFO:acro:records:add(): output_6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "             children                                          \n",
+      "recommend   not_recom  priority spec_prior very_recom       All\n",
+      "parents                                                        \n",
+      "great_pret   3.100694  2.627040   3.307122        NaN  3.103241\n",
+      "pretentious  3.143750  3.022237   3.336234   2.227273  3.130324\n",
+      "usual        3.111806  3.120062   3.323219   2.178571  3.110236\n",
+      "All          3.118750  2.986873   3.319238   2.198171  3.114601\n"
+     ]
+    }
+   ],
+   "source": [
+    "safe_table = acro.pivot_table(\n",
+    "    df, columns=[\"recommend\"], index=[\"parents\"], values=[\"children\"], margins=True\n",
+    ")\n",
+    "print(safe_table)"
    ]
   },
   {
@@ -661,7 +826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "72aefb22",
    "metadata": {
     "slideshow": {
@@ -706,7 +871,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "2f462e42",
    "metadata": {
     "scrolled": true,
@@ -726,7 +891,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:records:add(): output_4\n"
+      "INFO:acro:records:add(): output_7\n"
      ]
     },
     {
@@ -735,19 +900,19 @@
        "<table class=\"simpletable\">\n",
        "<caption>OLS Regression Results</caption>\n",
        "<tr>\n",
-       "  <th>Dep. Variable:</th>        <td>recommend</td>    <th>  R-squared:         </th> <td>   0.001</td> \n",
+       "  <th>Dep. Variable:</th>        <td>recommend</td>    <th>  R-squared:         </th> <td>   0.000</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Model:</th>                   <td>OLS</td>       <th>  Adj. R-squared:    </th> <td>   0.001</td> \n",
+       "  <th>Model:</th>                   <td>OLS</td>       <th>  Adj. R-squared:    </th> <td>   0.000</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Method:</th>             <td>Least Squares</td>  <th>  F-statistic:       </th> <td>   7.652</td> \n",
+       "  <th>Method:</th>             <td>Least Squares</td>  <th>  F-statistic:       </th> <td>   6.417</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>             <td>Tue, 30 Jan 2024</td> <th>  Prob (F-statistic):</th>  <td>0.00568</td> \n",
+       "  <th>Date:</th>             <td>Mon, 04 Mar 2024</td> <th>  Prob (F-statistic):</th>  <td>0.0113</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                 <td>14:09:59</td>     <th>  Log-Likelihood:    </th> <td> -25124.</td> \n",
+       "  <th>Time:</th>                 <td>21:21:09</td>     <th>  Log-Likelihood:    </th> <td> -25124.</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>No. Observations:</th>      <td> 12960</td>      <th>  AIC:               </th> <td>5.025e+04</td>\n",
@@ -767,24 +932,24 @@
        "      <td></td>        <th>coef</th>     <th>std err</th>      <th>t</th>      <th>P>|t|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>const</th>    <td>    2.2291</td> <td>    0.025</td> <td>   87.594</td> <td> 0.000</td> <td>    2.179</td> <td>    2.279</td>\n",
+       "  <th>const</th>    <td>    2.2341</td> <td>    0.025</td> <td>   87.965</td> <td> 0.000</td> <td>    2.184</td> <td>    2.284</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>children</th> <td>    0.0184</td> <td>    0.007</td> <td>    2.766</td> <td> 0.006</td> <td>    0.005</td> <td>    0.031</td>\n",
+       "  <th>children</th> <td>    0.0168</td> <td>    0.007</td> <td>    2.533</td> <td> 0.011</td> <td>    0.004</td> <td>    0.030</td>\n",
        "</tr>\n",
        "</table>\n",
        "<table class=\"simpletable\">\n",
        "<tr>\n",
-       "  <th>Omnibus:</th>       <td>76792.958</td> <th>  Durbin-Watson:     </th> <td>   2.884</td>\n",
+       "  <th>Omnibus:</th>       <td>76735.931</td> <th>  Durbin-Watson:     </th> <td>   2.883</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Prob(Omnibus):</th>  <td> 0.000</td>   <th>  Jarque-Bera (JB):  </th> <td>1743.166</td>\n",
+       "  <th>Prob(Omnibus):</th>  <td> 0.000</td>   <th>  Jarque-Bera (JB):  </th> <td>1742.843</td>\n",
        "</tr>\n",
        "<tr>\n",
        "  <th>Skew:</th>           <td>-0.485</td>   <th>  Prob(JB):          </th> <td>    0.00</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Kurtosis:</th>       <td> 1.488</td>   <th>  Cond. No.          </th> <td>    6.89</td>\n",
+       "  <th>Kurtosis:</th>       <td> 1.487</td>   <th>  Cond. No.          </th> <td>    6.89</td>\n",
        "</tr>\n",
        "</table><br/><br/>Notes:<br/>[1] Standard Errors assume that the covariance matrix of the errors is correctly specified."
       ],
@@ -793,11 +958,11 @@
        "\"\"\"\n",
        "                            OLS Regression Results                            \n",
        "==============================================================================\n",
-       "Dep. Variable:              recommend   R-squared:                       0.001\n",
-       "Model:                            OLS   Adj. R-squared:                  0.001\n",
-       "Method:                 Least Squares   F-statistic:                     7.652\n",
-       "Date:                Tue, 30 Jan 2024   Prob (F-statistic):            0.00568\n",
-       "Time:                        14:09:59   Log-Likelihood:                -25124.\n",
+       "Dep. Variable:              recommend   R-squared:                       0.000\n",
+       "Model:                            OLS   Adj. R-squared:                  0.000\n",
+       "Method:                 Least Squares   F-statistic:                     6.417\n",
+       "Date:                Mon, 04 Mar 2024   Prob (F-statistic):             0.0113\n",
+       "Time:                        21:21:09   Log-Likelihood:                -25124.\n",
        "No. Observations:               12960   AIC:                         5.025e+04\n",
        "Df Residuals:                   12958   BIC:                         5.027e+04\n",
        "Df Model:                           1                                         \n",
@@ -805,13 +970,13 @@
        "==============================================================================\n",
        "                 coef    std err          t      P>|t|      [0.025      0.975]\n",
        "------------------------------------------------------------------------------\n",
-       "const          2.2291      0.025     87.594      0.000       2.179       2.279\n",
-       "children       0.0184      0.007      2.766      0.006       0.005       0.031\n",
+       "const          2.2341      0.025     87.965      0.000       2.184       2.284\n",
+       "children       0.0168      0.007      2.533      0.011       0.004       0.030\n",
        "==============================================================================\n",
-       "Omnibus:                    76792.958   Durbin-Watson:                   2.884\n",
-       "Prob(Omnibus):                  0.000   Jarque-Bera (JB):             1743.166\n",
+       "Omnibus:                    76735.931   Durbin-Watson:                   2.883\n",
+       "Prob(Omnibus):                  0.000   Jarque-Bera (JB):             1742.843\n",
        "Skew:                          -0.485   Prob(JB):                         0.00\n",
-       "Kurtosis:                       1.488   Cond. No.                         6.89\n",
+       "Kurtosis:                       1.487   Cond. No.                         6.89\n",
        "==============================================================================\n",
        "\n",
        "Notes:\n",
@@ -819,7 +984,7 @@
        "\"\"\""
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -848,7 +1013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "cc90f7c9",
    "metadata": {
     "slideshow": {
@@ -867,7 +1032,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:records:add(): output_5\n"
+      "INFO:acro:records:add(): output_8\n"
      ]
     },
     {
@@ -876,11 +1041,11 @@
      "text": [
       "                            OLS Regression Results                            \n",
       "==============================================================================\n",
-      "Dep. Variable:              recommend   R-squared:                       0.001\n",
-      "Model:                            OLS   Adj. R-squared:                  0.001\n",
-      "Method:                 Least Squares   F-statistic:                     7.652\n",
-      "Date:                Tue, 30 Jan 2024   Prob (F-statistic):            0.00568\n",
-      "Time:                        14:09:59   Log-Likelihood:                -25124.\n",
+      "Dep. Variable:              recommend   R-squared:                       0.000\n",
+      "Model:                            OLS   Adj. R-squared:                  0.000\n",
+      "Method:                 Least Squares   F-statistic:                     6.417\n",
+      "Date:                Mon, 04 Mar 2024   Prob (F-statistic):             0.0113\n",
+      "Time:                        21:21:09   Log-Likelihood:                -25124.\n",
       "No. Observations:               12960   AIC:                         5.025e+04\n",
       "Df Residuals:                   12958   BIC:                         5.027e+04\n",
       "Df Model:                           1                                         \n",
@@ -888,13 +1053,13 @@
       "==============================================================================\n",
       "                 coef    std err          t      P>|t|      [0.025      0.975]\n",
       "------------------------------------------------------------------------------\n",
-      "Intercept      2.2291      0.025     87.594      0.000       2.179       2.279\n",
-      "children       0.0184      0.007      2.766      0.006       0.005       0.031\n",
+      "Intercept      2.2341      0.025     87.965      0.000       2.184       2.284\n",
+      "children       0.0168      0.007      2.533      0.011       0.004       0.030\n",
       "==============================================================================\n",
-      "Omnibus:                    76792.958   Durbin-Watson:                   2.884\n",
-      "Prob(Omnibus):                  0.000   Jarque-Bera (JB):             1743.166\n",
+      "Omnibus:                    76735.931   Durbin-Watson:                   2.883\n",
+      "Prob(Omnibus):                  0.000   Jarque-Bera (JB):             1742.843\n",
       "Skew:                          -0.485   Prob(JB):                         0.00\n",
-      "Kurtosis:                       1.488   Cond. No.                         6.89\n",
+      "Kurtosis:                       1.487   Cond. No.                         6.89\n",
       "==============================================================================\n",
       "\n",
       "Notes:\n",
@@ -925,7 +1090,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "5b1a1611",
    "metadata": {
     "slideshow": {
@@ -938,7 +1103,7 @@
      "output_type": "stream",
      "text": [
       "INFO:acro:probit() outcome: pass; dof=12958.0 >= 10\n",
-      "INFO:acro:records:add(): output_6\n"
+      "INFO:acro:records:add(): output_9\n"
      ]
     },
     {
@@ -946,22 +1111,22 @@
      "output_type": "stream",
      "text": [
       "Optimization terminated successfully.\n",
-      "         Current function value: 0.693113\n",
-      "         Iterations 3\n",
+      "         Current function value: 0.693146\n",
+      "         Iterations 2\n",
       "                          Probit Regression Results                           \n",
       "==============================================================================\n",
       "Dep. Variable:                finance   No. Observations:                12960\n",
       "Model:                         Probit   Df Residuals:                    12958\n",
       "Method:                           MLE   Df Model:                            1\n",
-      "Date:                Tue, 30 Jan 2024   Pseudo R-squ.:               4.993e-05\n",
-      "Time:                        14:10:00   Log-Likelihood:                -8982.7\n",
+      "Date:                Mon, 04 Mar 2024   Pseudo R-squ.:               1.186e-06\n",
+      "Time:                        21:21:09   Log-Likelihood:                -8983.2\n",
       "converged:                       True   LL-Null:                       -8983.2\n",
-      "Covariance Type:            nonrobust   LLR p-value:                    0.3436\n",
+      "Covariance Type:            nonrobust   LLR p-value:                    0.8839\n",
       "==============================================================================\n",
       "                 coef    std err          z      P>|z|      [0.025      0.975]\n",
       "------------------------------------------------------------------------------\n",
-      "const          0.0146      0.019      0.771      0.441      -0.023       0.052\n",
-      "children      -0.0047      0.005     -0.947      0.344      -0.014       0.005\n",
+      "const         -0.0022      0.019     -0.119      0.905      -0.039       0.035\n",
+      "children       0.0007      0.005      0.146      0.884      -0.009       0.010\n",
       "==============================================================================\n"
      ]
     }
@@ -994,7 +1159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "dcf30f8f",
    "metadata": {
     "slideshow": {
@@ -1002,6 +1167,15 @@
     }
    },
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Optimization terminated successfully.\n",
+      "         Current function value: 0.693146\n",
+      "         Iterations 2\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -1013,16 +1187,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:records:add(): output_7\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Optimization terminated successfully.\n",
-      "         Current function value: 0.693113\n",
-      "         Iterations 3\n"
+      "INFO:acro:records:add(): output_10\n"
      ]
     },
     {
@@ -1040,16 +1205,16 @@
        "  <th>Method:</th>                 <td>MLE</td>       <th>  Df Model:          </th>  <td>     1</td>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Date:</th>            <td>Tue, 30 Jan 2024</td> <th>  Pseudo R-squ.:     </th> <td>4.993e-05</td>\n",
+       "  <th>Date:</th>            <td>Mon, 04 Mar 2024</td> <th>  Pseudo R-squ.:     </th> <td>1.186e-06</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Time:</th>                <td>14:10:00</td>     <th>  Log-Likelihood:    </th> <td> -8982.7</td> \n",
+       "  <th>Time:</th>                <td>21:21:09</td>     <th>  Log-Likelihood:    </th> <td> -8983.2</td> \n",
        "</tr>\n",
        "<tr>\n",
        "  <th>converged:</th>             <td>True</td>       <th>  LL-Null:           </th> <td> -8983.2</td> \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>Covariance Type:</th>     <td>nonrobust</td>    <th>  LLR p-value:       </th>  <td>0.3436</td>  \n",
+       "  <th>Covariance Type:</th>     <td>nonrobust</td>    <th>  LLR p-value:       </th>  <td>0.8839</td>  \n",
        "</tr>\n",
        "</table>\n",
        "<table class=\"simpletable\">\n",
@@ -1057,10 +1222,10 @@
        "      <td></td>        <th>coef</th>     <th>std err</th>      <th>z</th>      <th>P>|z|</th>  <th>[0.025</th>    <th>0.975]</th>  \n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>const</th>    <td>    0.0233</td> <td>    0.030</td> <td>    0.771</td> <td> 0.441</td> <td>   -0.036</td> <td>    0.083</td>\n",
+       "  <th>const</th>    <td>   -0.0036</td> <td>    0.030</td> <td>   -0.119</td> <td> 0.905</td> <td>   -0.063</td> <td>    0.056</td>\n",
        "</tr>\n",
        "<tr>\n",
-       "  <th>children</th> <td>   -0.0075</td> <td>    0.008</td> <td>   -0.947</td> <td> 0.344</td> <td>   -0.023</td> <td>    0.008</td>\n",
+       "  <th>children</th> <td>    0.0012</td> <td>    0.008</td> <td>    0.146</td> <td> 0.884</td> <td>   -0.014</td> <td>    0.017</td>\n",
        "</tr>\n",
        "</table>"
       ],
@@ -1072,20 +1237,20 @@
        "Dep. Variable:                finance   No. Observations:                12960\n",
        "Model:                          Logit   Df Residuals:                    12958\n",
        "Method:                           MLE   Df Model:                            1\n",
-       "Date:                Tue, 30 Jan 2024   Pseudo R-squ.:               4.993e-05\n",
-       "Time:                        14:10:00   Log-Likelihood:                -8982.7\n",
+       "Date:                Mon, 04 Mar 2024   Pseudo R-squ.:               1.186e-06\n",
+       "Time:                        21:21:09   Log-Likelihood:                -8983.2\n",
        "converged:                       True   LL-Null:                       -8983.2\n",
-       "Covariance Type:            nonrobust   LLR p-value:                    0.3436\n",
+       "Covariance Type:            nonrobust   LLR p-value:                    0.8839\n",
        "==============================================================================\n",
        "                 coef    std err          z      P>|z|      [0.025      0.975]\n",
        "------------------------------------------------------------------------------\n",
-       "const          0.0233      0.030      0.771      0.441      -0.036       0.083\n",
-       "children      -0.0075      0.008     -0.947      0.344      -0.023       0.008\n",
+       "const         -0.0036      0.030     -0.119      0.905      -0.063       0.056\n",
+       "children       0.0012      0.008      0.146      0.884      -0.014       0.017\n",
        "==============================================================================\n",
        "\"\"\""
       ]
      },
-     "execution_count": 18,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1109,7 +1274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "dcf2c86d",
    "metadata": {},
    "outputs": [],
@@ -1124,7 +1289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "df1cbb9e",
    "metadata": {},
    "outputs": [
@@ -1160,7 +1325,7 @@
       "3309 | thr|e|shold;   threshold|;  || th|res|hold;   thr|eshold; |\n",
       "-----------------------------------------------------------------|\n",
       "\n",
-      "INFO:acro:records:add(): output_8\n"
+      "INFO:acro:records:add(): output_11\n"
      ]
     },
     {
@@ -1199,7 +1364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "id": "8762ab29",
    "metadata": {},
    "outputs": [
@@ -1241,7 +1406,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:records:add(): output_9\n"
+      "INFO:acro:records:add(): output_12\n"
      ]
     },
     {
@@ -1286,7 +1451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "id": "ec960039",
    "metadata": {
     "scrolled": true,
@@ -1306,25 +1471,51 @@
       "sdc: {'summary': {'suppressed': True, 'negative': 0, 'missing': 0, 'threshold': 4, 'p-ratio': 0, 'nk-rule': 0, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[2, 0], [2, 1], [2, 2], [4, 0]], 'p-ratio': [], 'nk-rule': [], 'all-values-are-same': []}}\n",
       "command: safe_table = acro.crosstab(\n",
       "summary: fail; threshold: 4 cells suppressed; \n",
-      "outcome: parents          great_pret  pretentious        usual\n",
-      "recommendation                                       \n",
-      "not_recom                ok           ok           ok\n",
-      "priority                 ok           ok           ok\n",
-      "recommend       threshold;   threshold;   threshold; \n",
-      "spec_prior               ok           ok           ok\n",
-      "very_recom      threshold;            ok           ok\n",
-      "output: [parents         great_pret  pretentious   usual\n",
-      "recommendation                                 \n",
-      "not_recom           1440.0       1440.0  1440.0\n",
-      "priority             858.0       1484.0  1924.0\n",
-      "recommend              NaN          NaN     NaN\n",
-      "spec_prior          2022.0       1264.0   758.0\n",
-      "very_recom             NaN        132.0   196.0]\n",
-      "timestamp: 2024-01-30T14:09:59.298279\n",
+      "outcome: parents      great_pret  pretentious        usual\n",
+      "recommend                                        \n",
+      "not_recom            ok           ok           ok\n",
+      "priority             ok           ok           ok\n",
+      "recommend   threshold;   threshold;   threshold; \n",
+      "spec_prior           ok           ok           ok\n",
+      "very_recom  threshold;            ok           ok\n",
+      "output: [parents     great_pret  pretentious   usual\n",
+      "recommend                                  \n",
+      "not_recom       1440.0       1440.0  1440.0\n",
+      "priority         858.0       1484.0  1924.0\n",
+      "recommend          NaN          NaN     NaN\n",
+      "spec_prior      2022.0       1264.0   758.0\n",
+      "very_recom         NaN        132.0   196.0]\n",
+      "timestamp: 2024-03-04T21:21:07.616714\n",
       "comments: []\n",
       "exception: \n",
       "\n",
       "uid: output_1\n",
+      "status: fail\n",
+      "type: table\n",
+      "properties: {'method': 'crosstab'}\n",
+      "sdc: {'summary': {'suppressed': True, 'negative': 0, 'missing': 0, 'threshold': 5, 'p-ratio': 0, 'nk-rule': 0, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[2, 0], [2, 1], [2, 2], [2, 3], [4, 0]], 'p-ratio': [], 'nk-rule': [], 'all-values-are-same': []}}\n",
+      "command: safe_table = acro.crosstab(\n",
+      "summary: fail; threshold: 5 cells suppressed; \n",
+      "outcome: parents      great_pret  pretentious        usual          All\n",
+      "recommend                                                     \n",
+      "not_recom            ok           ok           ok           ok\n",
+      "priority             ok           ok           ok           ok\n",
+      "recommend   threshold;   threshold;   threshold;   threshold; \n",
+      "spec_prior           ok           ok           ok           ok\n",
+      "very_recom  threshold;            ok           ok           ok\n",
+      "All                  ok           ok           ok           ok\n",
+      "output: [parents     great_pret  pretentious  usual    All\n",
+      "recommend                                        \n",
+      "not_recom       1440.0         1440   1440   4320\n",
+      "priority         858.0         1484   1924   4266\n",
+      "spec_prior      2022.0         1264    758   4044\n",
+      "very_recom         NaN          132    196    328\n",
+      "All             4320.0         4320   4318  12958]\n",
+      "timestamp: 2024-03-04T21:21:07.845655\n",
+      "comments: []\n",
+      "exception: \n",
+      "\n",
+      "uid: output_2\n",
       "status: fail\n",
       "type: table\n",
       "properties: {'method': 'crosstab'}\n",
@@ -1345,16 +1536,16 @@
       "recommend            0            0      2\n",
       "spec_prior        2022         1264    758\n",
       "very_recom           0          132    196]\n",
-      "timestamp: 2024-01-30T14:09:59.381804\n",
+      "timestamp: 2024-03-04T21:21:07.967630\n",
       "comments: []\n",
       "exception: \n",
       "\n",
-      "uid: output_2\n",
+      "uid: output_3\n",
       "status: fail\n",
       "type: table\n",
       "properties: {'method': 'crosstab'}\n",
       "sdc: {'summary': {'suppressed': True, 'negative': 0, 'missing': 0, 'threshold': 1, 'p-ratio': 4, 'nk-rule': 4, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[2, 2]], 'p-ratio': [[2, 0], [2, 1], [2, 2], [4, 0]], 'nk-rule': [[2, 0], [2, 1], [2, 2], [4, 0]], 'all-values-are-same': []}}\n",
-      "command: safe_table = acro.crosstab(df.recommend, df.parents, values=df.children, aggfunc=\"mean\")\n",
+      "command: safe_table = acro.crosstab(\n",
       "summary: fail; threshold: 1 cells suppressed; p-ratio: 4 cells suppressed; nk-rule: 4 cells suppressed; \n",
       "outcome: parents             great_pret         pretentious  \\\n",
       "recommend                                            \n",
@@ -1371,18 +1562,63 @@
       "recommend   threshold; p-ratio; nk-rule;   \n",
       "spec_prior                             ok  \n",
       "very_recom                             ok  \n",
-      "output: [parents     great_pret  pretentious     usual\n",
-      "recommend                                    \n",
-      "not_recom     3.147222     3.097917  3.093750\n",
-      "priority      2.636364     3.000674  3.075364\n",
-      "recommend          NaN          NaN       NaN\n",
-      "spec_prior    3.345697     3.332278  3.317942\n",
-      "very_recom         NaN     2.227273  2.229592]\n",
-      "timestamp: 2024-01-30T14:09:59.519976\n",
+      "output: [parents     great_pret  pretentious   usual\n",
+      "recommend                                  \n",
+      "not_recom       1440.0       1440.0  1440.0\n",
+      "priority         858.0       1484.0  1924.0\n",
+      "recommend          NaN          NaN     NaN\n",
+      "spec_prior      2022.0       1264.0   758.0\n",
+      "very_recom         NaN        132.0   196.0]\n",
+      "timestamp: 2024-03-04T21:21:08.142362\n",
       "comments: []\n",
       "exception: \n",
       "\n",
-      "uid: output_3\n",
+      "uid: output_4\n",
+      "status: fail\n",
+      "type: table\n",
+      "properties: {'method': 'crosstab'}\n",
+      "sdc: {'summary': {'suppressed': True, 'negative': 0, 'missing': 0, 'threshold': 2, 'p-ratio': 8, 'nk-rule': 8, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[2, 2], [2, 5]], 'p-ratio': [[2, 0], [2, 1], [2, 2], [2, 3], [2, 4], [2, 5], [4, 0], [4, 3]], 'nk-rule': [[2, 0], [2, 1], [2, 2], [2, 3], [2, 4], [2, 5], [4, 0], [4, 3]], 'all-values-are-same': []}}\n",
+      "command: safe_table = acro.crosstab(\n",
+      "summary: fail; threshold: 2 cells suppressed; p-ratio: 8 cells suppressed; nk-rule: 8 cells suppressed; \n",
+      "outcome:                   mode_aggfunc                      \\\n",
+      "parents             great_pret         pretentious   \n",
+      "recommend                                            \n",
+      "not_recom                   ok                  ok   \n",
+      "priority                    ok                  ok   \n",
+      "recommend   p-ratio; nk-rule;   p-ratio; nk-rule;    \n",
+      "spec_prior                  ok                  ok   \n",
+      "very_recom  p-ratio; nk-rule;                   ok   \n",
+      "\n",
+      "                                                         mean  \\\n",
+      "parents                             usual          great_pret   \n",
+      "recommend                                                       \n",
+      "not_recom                              ok                  ok   \n",
+      "priority                               ok                  ok   \n",
+      "recommend   threshold; p-ratio; nk-rule;   p-ratio; nk-rule;    \n",
+      "spec_prior                             ok                  ok   \n",
+      "very_recom                             ok  p-ratio; nk-rule;    \n",
+      "\n",
+      "                                                               \n",
+      "parents            pretentious                          usual  \n",
+      "recommend                                                      \n",
+      "not_recom                   ok                             ok  \n",
+      "priority                    ok                             ok  \n",
+      "recommend   p-ratio; nk-rule;   threshold; p-ratio; nk-rule;   \n",
+      "spec_prior                  ok                             ok  \n",
+      "very_recom                  ok                             ok  \n",
+      "output: [           mode_aggfunc                         mean                      \n",
+      "parents      great_pret pretentious usual great_pret pretentious     usual\n",
+      "recommend                                                                 \n",
+      "not_recom           3.0         2.0   1.0   3.100694    3.143750  3.111806\n",
+      "priority            1.0         1.0   1.0   2.627040    3.022237  3.120062\n",
+      "recommend           NaN         NaN   NaN        NaN         NaN       NaN\n",
+      "spec_prior          3.0         3.0   3.0   3.307122    3.336234  3.323219\n",
+      "very_recom          NaN         1.0   1.0        NaN    2.227273  2.178571]\n",
+      "timestamp: 2024-03-04T21:21:08.334715\n",
+      "comments: []\n",
+      "exception: \n",
+      "\n",
+      "uid: output_5\n",
       "status: pass\n",
       "type: table\n",
       "properties: {'method': 'pivot_table'}\n",
@@ -1398,14 +1634,47 @@
       "output: [                 mean       std\n",
       "             children  children\n",
       "parents                        \n",
-      "great_pret   3.138657  2.257859\n",
-      "pretentious  3.106481  2.216308\n",
-      "usual        3.084722  2.175608]\n",
-      "timestamp: 2024-01-30T14:09:59.637985\n",
+      "great_pret   3.103241  2.213116\n",
+      "pretentious  3.130324  2.250447\n",
+      "usual        3.109259  2.216799]\n",
+      "timestamp: 2024-03-04T21:21:08.485335\n",
       "comments: []\n",
       "exception: \n",
       "\n",
-      "uid: output_4\n",
+      "uid: output_6\n",
+      "status: fail\n",
+      "type: table\n",
+      "properties: {'method': 'pivot_table'}\n",
+      "sdc: {'summary': {'suppressed': True, 'negative': 0, 'missing': 0, 'threshold': 5, 'p-ratio': 5, 'nk-rule': 5, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[0, 2], [0, 4], [1, 2], [2, 2], [3, 2]], 'p-ratio': [[0, 2], [0, 4], [1, 2], [2, 2], [3, 2]], 'nk-rule': [[0, 2], [0, 4], [1, 2], [2, 2], [3, 2]], 'all-values-are-same': []}}\n",
+      "command: safe_table = acro.pivot_table(\n",
+      "summary: fail; threshold: 5 cells suppressed; p-ratio: 5 cells suppressed; nk-rule: 5 cells suppressed; \n",
+      "outcome:              children                                                     \\\n",
+      "recommend   not_recom priority                      recommend spec_prior   \n",
+      "parents                                                                    \n",
+      "great_pret         ok       ok  threshold; p-ratio; nk-rule;          ok   \n",
+      "pretentious        ok       ok  threshold; p-ratio; nk-rule;          ok   \n",
+      "usual              ok       ok  threshold; p-ratio; nk-rule;          ok   \n",
+      "All                ok       ok  threshold; p-ratio; nk-rule;          ok   \n",
+      "\n",
+      "                                                \n",
+      "recommend                       very_recom All  \n",
+      "parents                                         \n",
+      "great_pret   threshold; p-ratio; nk-rule;   ok  \n",
+      "pretentious                             ok  ok  \n",
+      "usual                                   ok  ok  \n",
+      "All                                     ok  ok  \n",
+      "output: [             children                                          \n",
+      "recommend   not_recom  priority spec_prior very_recom       All\n",
+      "parents                                                        \n",
+      "great_pret   3.100694  2.627040   3.307122        NaN  3.103241\n",
+      "pretentious  3.143750  3.022237   3.336234   2.227273  3.130324\n",
+      "usual        3.111806  3.120062   3.323219   2.178571  3.110236\n",
+      "All          3.118750  2.986873   3.319238   2.198171  3.114601]\n",
+      "timestamp: 2024-03-04T21:21:08.834120\n",
+      "comments: []\n",
+      "exception: \n",
+      "\n",
+      "uid: output_7\n",
       "status: pass\n",
       "type: regression\n",
       "properties: {'method': 'ols', 'dof': 12958.0}\n",
@@ -1415,27 +1684,27 @@
       "outcome: Empty DataFrame\n",
       "Columns: []\n",
       "Index: []\n",
-      "output: [                          recommend           R-squared:        0.001\n",
-      "Dep. Variable:                                                       \n",
-      "Model:                          OLS      Adj. R-squared:      0.00100\n",
-      "Method:               Least Squares         F-statistic:      7.65200\n",
-      "Date:              Tue, 30 Jan 2024  Prob (F-statistic):      0.00568\n",
-      "Time:                      14:09:59      Log-Likelihood: -25124.00000\n",
-      "No. Observations:             12960                 AIC:  50250.00000\n",
-      "Df Residuals:                 12958                 BIC:  50270.00000\n",
-      "Df Model:                         1                  NaN          NaN\n",
-      "Covariance Type:          nonrobust                  NaN          NaN,             coef  std err       t  P>|t|  [0.025  0.975]\n",
-      "const     2.2291    0.025  87.594  0.000   2.179   2.279\n",
-      "children  0.0184    0.007   2.766  0.006   0.005   0.031,                 76792.958     Durbin-Watson:     2.884\n",
+      "output: [                          recommend           R-squared:       0.000\n",
+      "Dep. Variable:                                                      \n",
+      "Model:                          OLS      Adj. R-squared:      0.0000\n",
+      "Method:               Least Squares         F-statistic:      6.4170\n",
+      "Date:              Mon, 04 Mar 2024  Prob (F-statistic):      0.0113\n",
+      "Time:                      21:21:09      Log-Likelihood: -25124.0000\n",
+      "No. Observations:             12960                 AIC:  50250.0000\n",
+      "Df Residuals:                 12958                 BIC:  50270.0000\n",
+      "Df Model:                         1                  NaN         NaN\n",
+      "Covariance Type:          nonrobust                  NaN         NaN,             coef  std err       t  P>|t|  [0.025  0.975]\n",
+      "const     2.2341    0.025  87.965  0.000   2.184   2.284\n",
+      "children  0.0168    0.007   2.533  0.011   0.004   0.030,                 76735.931     Durbin-Watson:     2.883\n",
       "Omnibus:                                              \n",
-      "Prob(Omnibus):      0.000  Jarque-Bera (JB):  1743.166\n",
+      "Prob(Omnibus):      0.000  Jarque-Bera (JB):  1742.843\n",
       "Skew:              -0.485          Prob(JB):     0.000\n",
-      "Kurtosis:           1.488          Cond. No.     6.890]\n",
-      "timestamp: 2024-01-30T14:09:59.809927\n",
+      "Kurtosis:           1.487          Cond. No.     6.890]\n",
+      "timestamp: 2024-03-04T21:21:09.117190\n",
       "comments: []\n",
       "exception: \n",
       "\n",
-      "uid: output_5\n",
+      "uid: output_8\n",
       "status: pass\n",
       "type: regression\n",
       "properties: {'method': 'olsr', 'dof': 12958.0}\n",
@@ -1445,27 +1714,27 @@
       "outcome: Empty DataFrame\n",
       "Columns: []\n",
       "Index: []\n",
-      "output: [                          recommend           R-squared:        0.001\n",
-      "Dep. Variable:                                                       \n",
-      "Model:                          OLS      Adj. R-squared:      0.00100\n",
-      "Method:               Least Squares         F-statistic:      7.65200\n",
-      "Date:              Tue, 30 Jan 2024  Prob (F-statistic):      0.00568\n",
-      "Time:                      14:09:59      Log-Likelihood: -25124.00000\n",
-      "No. Observations:             12960                 AIC:  50250.00000\n",
-      "Df Residuals:                 12958                 BIC:  50270.00000\n",
-      "Df Model:                         1                  NaN          NaN\n",
-      "Covariance Type:          nonrobust                  NaN          NaN,              coef  std err       t  P>|t|  [0.025  0.975]\n",
-      "Intercept  2.2291    0.025  87.594  0.000   2.179   2.279\n",
-      "children   0.0184    0.007   2.766  0.006   0.005   0.031,                 76792.958     Durbin-Watson:     2.884\n",
+      "output: [                          recommend           R-squared:       0.000\n",
+      "Dep. Variable:                                                      \n",
+      "Model:                          OLS      Adj. R-squared:      0.0000\n",
+      "Method:               Least Squares         F-statistic:      6.4170\n",
+      "Date:              Mon, 04 Mar 2024  Prob (F-statistic):      0.0113\n",
+      "Time:                      21:21:09      Log-Likelihood: -25124.0000\n",
+      "No. Observations:             12960                 AIC:  50250.0000\n",
+      "Df Residuals:                 12958                 BIC:  50270.0000\n",
+      "Df Model:                         1                  NaN         NaN\n",
+      "Covariance Type:          nonrobust                  NaN         NaN,              coef  std err       t  P>|t|  [0.025  0.975]\n",
+      "Intercept  2.2341    0.025  87.965  0.000   2.184   2.284\n",
+      "children   0.0168    0.007   2.533  0.011   0.004   0.030,                 76735.931     Durbin-Watson:     2.883\n",
       "Omnibus:                                              \n",
-      "Prob(Omnibus):      0.000  Jarque-Bera (JB):  1743.166\n",
+      "Prob(Omnibus):      0.000  Jarque-Bera (JB):  1742.843\n",
       "Skew:              -0.485          Prob(JB):     0.000\n",
-      "Kurtosis:           1.488          Cond. No.     6.890]\n",
-      "timestamp: 2024-01-30T14:09:59.899115\n",
+      "Kurtosis:           1.487          Cond. No.     6.890]\n",
+      "timestamp: 2024-03-04T21:21:09.224540\n",
       "comments: []\n",
       "exception: \n",
       "\n",
-      "uid: output_6\n",
+      "uid: output_9\n",
       "status: pass\n",
       "type: regression\n",
       "properties: {'method': 'probit', 'dof': 12958.0}\n",
@@ -1475,21 +1744,21 @@
       "outcome: Empty DataFrame\n",
       "Columns: []\n",
       "Index: []\n",
-      "output: [                           finance No. Observations:        12960\n",
-      "Dep. Variable:                                                   \n",
-      "Model:                      Probit     Df Residuals:  12958.00000\n",
-      "Method:                        MLE         Df Model:      1.00000\n",
-      "Date:             Tue, 30 Jan 2024    Pseudo R-squ.:      0.00005\n",
-      "Time:                     14:10:00   Log-Likelihood:  -8982.70000\n",
-      "converged:                    True          LL-Null:  -8983.20000\n",
-      "Covariance Type:         nonrobust      LLR p-value:      0.34360,             coef  std err      z  P>|z|  [0.025  0.975]\n",
-      "const     0.0146    0.019  0.771  0.441  -0.023   0.052\n",
-      "children -0.0047    0.005 -0.947  0.344  -0.014   0.005]\n",
-      "timestamp: 2024-01-30T14:10:00.028113\n",
+      "output: [                           finance No. Observations:         12960\n",
+      "Dep. Variable:                                                    \n",
+      "Model:                      Probit     Df Residuals:  12958.000000\n",
+      "Method:                        MLE         Df Model:      1.000000\n",
+      "Date:             Mon, 04 Mar 2024    Pseudo R-squ.:      0.000001\n",
+      "Time:                     21:21:09   Log-Likelihood:  -8983.200000\n",
+      "converged:                    True          LL-Null:  -8983.200000\n",
+      "Covariance Type:         nonrobust      LLR p-value:      0.883900,             coef  std err      z  P>|z|  [0.025  0.975]\n",
+      "const    -0.0022    0.019 -0.119  0.905  -0.039   0.035\n",
+      "children  0.0007    0.005  0.146  0.884  -0.009   0.010]\n",
+      "timestamp: 2024-03-04T21:21:09.358683\n",
       "comments: []\n",
       "exception: \n",
       "\n",
-      "uid: output_7\n",
+      "uid: output_10\n",
       "status: pass\n",
       "type: regression\n",
       "properties: {'method': 'logit', 'dof': 12958.0}\n",
@@ -1499,21 +1768,21 @@
       "outcome: Empty DataFrame\n",
       "Columns: []\n",
       "Index: []\n",
-      "output: [                           finance No. Observations:        12960\n",
-      "Dep. Variable:                                                   \n",
-      "Model:                       Logit     Df Residuals:  12958.00000\n",
-      "Method:                        MLE         Df Model:      1.00000\n",
-      "Date:             Tue, 30 Jan 2024    Pseudo R-squ.:      0.00005\n",
-      "Time:                     14:10:00   Log-Likelihood:  -8982.70000\n",
-      "converged:                    True          LL-Null:  -8983.20000\n",
-      "Covariance Type:         nonrobust      LLR p-value:      0.34360,             coef  std err      z  P>|z|  [0.025  0.975]\n",
-      "const     0.0233    0.030  0.771  0.441  -0.036   0.083\n",
-      "children -0.0075    0.008 -0.947  0.344  -0.023   0.008]\n",
-      "timestamp: 2024-01-30T14:10:00.163252\n",
+      "output: [                           finance No. Observations:         12960\n",
+      "Dep. Variable:                                                    \n",
+      "Model:                       Logit     Df Residuals:  12958.000000\n",
+      "Method:                        MLE         Df Model:      1.000000\n",
+      "Date:             Mon, 04 Mar 2024    Pseudo R-squ.:      0.000001\n",
+      "Time:                     21:21:09   Log-Likelihood:  -8983.200000\n",
+      "converged:                    True          LL-Null:  -8983.200000\n",
+      "Covariance Type:         nonrobust      LLR p-value:      0.883900,             coef  std err      z  P>|z|  [0.025  0.975]\n",
+      "const    -0.0036    0.030 -0.119  0.905  -0.063   0.056\n",
+      "children  0.0012    0.008  0.146  0.884  -0.014   0.017]\n",
+      "timestamp: 2024-03-04T21:21:09.456005\n",
       "comments: []\n",
       "exception: \n",
       "\n",
-      "uid: output_8\n",
+      "uid: output_11\n",
       "status: fail\n",
       "type: table\n",
       "properties: {'method': 'surv_func'}\n",
@@ -1564,11 +1833,11 @@
       "2776        NaN           NaN          NaN         NaN\n",
       "2851        NaN           NaN          NaN         NaN\n",
       "3309        NaN           NaN          NaN         NaN]\n",
-      "timestamp: 2024-01-30T14:10:00.984548\n",
+      "timestamp: 2024-03-04T21:21:10.943849\n",
       "comments: []\n",
       "exception: \n",
       "\n",
-      "uid: output_9\n",
+      "uid: output_12\n",
       "status: fail\n",
       "type: survival plot\n",
       "properties: {'method': 'surv_func'}\n",
@@ -1579,7 +1848,7 @@
       "Columns: []\n",
       "Index: []\n",
       "output: ['acro_artifacts\\\\kaplan-mier_0.png']\n",
-      "timestamp: 2024-01-30T14:10:01.208677\n",
+      "timestamp: 2024-03-04T21:21:11.236799\n",
       "comments: []\n",
       "exception: \n",
       "\n",
@@ -1589,10 +1858,10 @@
     {
      "data": {
       "text/plain": [
-       "'uid: output_0\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'crosstab\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 4, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[2, 0], [2, 1], [2, 2], [4, 0]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.crosstab(\\nsummary: fail; threshold: 4 cells suppressed; \\noutcome: parents          great_pret  pretentious        usual\\nrecommendation                                       \\nnot_recom                ok           ok           ok\\npriority                 ok           ok           ok\\nrecommend       threshold;   threshold;   threshold; \\nspec_prior               ok           ok           ok\\nvery_recom      threshold;            ok           ok\\noutput: [parents         great_pret  pretentious   usual\\nrecommendation                                 \\nnot_recom           1440.0       1440.0  1440.0\\npriority             858.0       1484.0  1924.0\\nrecommend              NaN          NaN     NaN\\nspec_prior          2022.0       1264.0   758.0\\nvery_recom             NaN        132.0   196.0]\\ntimestamp: 2024-01-30T14:09:59.298279\\ncomments: []\\nexception: \\n\\nuid: output_1\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'crosstab\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': False, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 4, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[2, 0], [2, 1], [2, 2], [4, 0]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.crosstab(df.recommend, df.parents)\\nsummary: fail; threshold: 4 cells may need suppressing; \\noutcome: parents      great_pret  pretentious        usual\\nrecommend                                        \\nnot_recom            ok           ok           ok\\npriority             ok           ok           ok\\nrecommend   threshold;   threshold;   threshold; \\nspec_prior           ok           ok           ok\\nvery_recom  threshold;            ok           ok\\noutput: [parents     great_pret  pretentious  usual\\nrecommend                                 \\nnot_recom         1440         1440   1440\\npriority           858         1484   1924\\nrecommend            0            0      2\\nspec_prior        2022         1264    758\\nvery_recom           0          132    196]\\ntimestamp: 2024-01-30T14:09:59.381804\\ncomments: []\\nexception: \\n\\nuid: output_2\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'crosstab\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 1, \\'p-ratio\\': 4, \\'nk-rule\\': 4, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[2, 2]], \\'p-ratio\\': [[2, 0], [2, 1], [2, 2], [4, 0]], \\'nk-rule\\': [[2, 0], [2, 1], [2, 2], [4, 0]], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.crosstab(df.recommend, df.parents, values=df.children, aggfunc=\"mean\")\\nsummary: fail; threshold: 1 cells suppressed; p-ratio: 4 cells suppressed; nk-rule: 4 cells suppressed; \\noutcome: parents             great_pret         pretentious  \\\\\\nrecommend                                            \\nnot_recom                   ok                  ok   \\npriority                    ok                  ok   \\nrecommend   p-ratio; nk-rule;   p-ratio; nk-rule;    \\nspec_prior                  ok                  ok   \\nvery_recom  p-ratio; nk-rule;                   ok   \\n\\nparents                             usual  \\nrecommend                                  \\nnot_recom                              ok  \\npriority                               ok  \\nrecommend   threshold; p-ratio; nk-rule;   \\nspec_prior                             ok  \\nvery_recom                             ok  \\noutput: [parents     great_pret  pretentious     usual\\nrecommend                                    \\nnot_recom     3.147222     3.097917  3.093750\\npriority      2.636364     3.000674  3.075364\\nrecommend          NaN          NaN       NaN\\nspec_prior    3.345697     3.332278  3.317942\\nvery_recom         NaN     2.227273  2.229592]\\ntimestamp: 2024-01-30T14:09:59.519976\\ncomments: []\\nexception: \\n\\nuid: output_3\\nstatus: pass\\ntype: table\\nproperties: {\\'method\\': \\'pivot_table\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 0, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: table = acro.pivot_table(\\nsummary: pass\\noutcome:                 mean      std\\n            children children\\nparents                      \\ngreat_pret        ok       ok\\npretentious       ok       ok\\nusual             ok       ok\\noutput: [                 mean       std\\n             children  children\\nparents                        \\ngreat_pret   3.138657  2.257859\\npretentious  3.106481  2.216308\\nusual        3.084722  2.175608]\\ntimestamp: 2024-01-30T14:09:59.637985\\ncomments: []\\nexception: \\n\\nuid: output_4\\nstatus: pass\\ntype: regression\\nproperties: {\\'method\\': \\'ols\\', \\'dof\\': 12958.0}\\nsdc: {}\\ncommand: results = acro.ols(y, x)\\nsummary: pass; dof=12958.0 >= 10\\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [                          recommend           R-squared:        0.001\\nDep. Variable:                                                       \\nModel:                          OLS      Adj. R-squared:      0.00100\\nMethod:               Least Squares         F-statistic:      7.65200\\nDate:              Tue, 30 Jan 2024  Prob (F-statistic):      0.00568\\nTime:                      14:09:59      Log-Likelihood: -25124.00000\\nNo. Observations:             12960                 AIC:  50250.00000\\nDf Residuals:                 12958                 BIC:  50270.00000\\nDf Model:                         1                  NaN          NaN\\nCovariance Type:          nonrobust                  NaN          NaN,             coef  std err       t  P>|t|  [0.025  0.975]\\nconst     2.2291    0.025  87.594  0.000   2.179   2.279\\nchildren  0.0184    0.007   2.766  0.006   0.005   0.031,                 76792.958     Durbin-Watson:     2.884\\nOmnibus:                                              \\nProb(Omnibus):      0.000  Jarque-Bera (JB):  1743.166\\nSkew:              -0.485          Prob(JB):     0.000\\nKurtosis:           1.488          Cond. No.     6.890]\\ntimestamp: 2024-01-30T14:09:59.809927\\ncomments: []\\nexception: \\n\\nuid: output_5\\nstatus: pass\\ntype: regression\\nproperties: {\\'method\\': \\'olsr\\', \\'dof\\': 12958.0}\\nsdc: {}\\ncommand: results = acro.olsr(formula=\"recommend ~ children\", data=new_df)\\nsummary: pass; dof=12958.0 >= 10\\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [                          recommend           R-squared:        0.001\\nDep. Variable:                                                       \\nModel:                          OLS      Adj. R-squared:      0.00100\\nMethod:               Least Squares         F-statistic:      7.65200\\nDate:              Tue, 30 Jan 2024  Prob (F-statistic):      0.00568\\nTime:                      14:09:59      Log-Likelihood: -25124.00000\\nNo. Observations:             12960                 AIC:  50250.00000\\nDf Residuals:                 12958                 BIC:  50270.00000\\nDf Model:                         1                  NaN          NaN\\nCovariance Type:          nonrobust                  NaN          NaN,              coef  std err       t  P>|t|  [0.025  0.975]\\nIntercept  2.2291    0.025  87.594  0.000   2.179   2.279\\nchildren   0.0184    0.007   2.766  0.006   0.005   0.031,                 76792.958     Durbin-Watson:     2.884\\nOmnibus:                                              \\nProb(Omnibus):      0.000  Jarque-Bera (JB):  1743.166\\nSkew:              -0.485          Prob(JB):     0.000\\nKurtosis:           1.488          Cond. No.     6.890]\\ntimestamp: 2024-01-30T14:09:59.899115\\ncomments: []\\nexception: \\n\\nuid: output_6\\nstatus: pass\\ntype: regression\\nproperties: {\\'method\\': \\'probit\\', \\'dof\\': 12958.0}\\nsdc: {}\\ncommand: results = acro.probit(y, x)\\nsummary: pass; dof=12958.0 >= 10\\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [                           finance No. Observations:        12960\\nDep. Variable:                                                   \\nModel:                      Probit     Df Residuals:  12958.00000\\nMethod:                        MLE         Df Model:      1.00000\\nDate:             Tue, 30 Jan 2024    Pseudo R-squ.:      0.00005\\nTime:                     14:10:00   Log-Likelihood:  -8982.70000\\nconverged:                    True          LL-Null:  -8983.20000\\nCovariance Type:         nonrobust      LLR p-value:      0.34360,             coef  std err      z  P>|z|  [0.025  0.975]\\nconst     0.0146    0.019  0.771  0.441  -0.023   0.052\\nchildren -0.0047    0.005 -0.947  0.344  -0.014   0.005]\\ntimestamp: 2024-01-30T14:10:00.028113\\ncomments: []\\nexception: \\n\\nuid: output_7\\nstatus: pass\\ntype: regression\\nproperties: {\\'method\\': \\'logit\\', \\'dof\\': 12958.0}\\nsdc: {}\\ncommand: results = acro.logit(y, x)\\nsummary: pass; dof=12958.0 >= 10\\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [                           finance No. Observations:        12960\\nDep. Variable:                                                   \\nModel:                       Logit     Df Residuals:  12958.00000\\nMethod:                        MLE         Df Model:      1.00000\\nDate:             Tue, 30 Jan 2024    Pseudo R-squ.:      0.00005\\nTime:                     14:10:00   Log-Likelihood:  -8982.70000\\nconverged:                    True          LL-Null:  -8983.20000\\nCovariance Type:         nonrobust      LLR p-value:      0.34360,             coef  std err      z  P>|z|  [0.025  0.975]\\nconst     0.0233    0.030  0.771  0.441  -0.036   0.083\\nchildren -0.0075    0.008 -0.947  0.344  -0.023   0.008]\\ntimestamp: 2024-01-30T14:10:00.163252\\ncomments: []\\nexception: \\n\\nuid: output_8\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'surv_func\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 76, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[1, 0], [1, 1], [1, 2], [1, 3], [2, 0], [2, 1], [2, 2], [2, 3], [3, 0], [3, 1], [3, 2], [3, 3], [4, 0], [4, 1], [4, 2], [4, 3], [5, 0], [5, 1], [5, 2], [5, 3], [6, 0], [6, 1], [6, 2], [6, 3], [7, 0], [7, 1], [7, 2], [7, 3], [8, 0], [8, 1], [8, 2], [8, 3], [9, 0], [9, 1], [9, 2], [9, 3], [10, 0], [10, 1], [10, 2], [10, 3], [11, 0], [11, 1], [11, 2], [11, 3], [12, 0], [12, 1], [12, 2], [12, 3], [13, 0], [13, 1], [13, 2], [13, 3], [14, 0], [14, 1], [14, 2], [14, 3], [15, 0], [15, 1], [15, 2], [15, 3], [16, 0], [16, 1], [16, 2], [16, 3], [17, 0], [17, 1], [17, 2], [17, 3], [18, 0], [18, 1], [18, 2], [18, 3], [19, 0], [19, 1], [19, 2], [19, 3]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.surv_func(data.futime, data.death, output=\"table\")\\nsummary: fail; threshold: 76 cells suppressed; \\noutcome:         Surv prob Surv prob SE  num at risk   num events\\nTime                                                    \\n51             ok           ok           ok           ok\\n69    threshold;   threshold;   threshold;   threshold; \\n85    threshold;   threshold;   threshold;   threshold; \\n91    threshold;   threshold;   threshold;   threshold; \\n115   threshold;   threshold;   threshold;   threshold; \\n372   threshold;   threshold;   threshold;   threshold; \\n667   threshold;   threshold;   threshold;   threshold; \\n874   threshold;   threshold;   threshold;   threshold; \\n1039  threshold;   threshold;   threshold;   threshold; \\n1046  threshold;   threshold;   threshold;   threshold; \\n1281  threshold;   threshold;   threshold;   threshold; \\n1286  threshold;   threshold;   threshold;   threshold; \\n1326  threshold;   threshold;   threshold;   threshold; \\n1355  threshold;   threshold;   threshold;   threshold; \\n1626  threshold;   threshold;   threshold;   threshold; \\n1903  threshold;   threshold;   threshold;   threshold; \\n1914  threshold;   threshold;   threshold;   threshold; \\n2776  threshold;   threshold;   threshold;   threshold; \\n2851  threshold;   threshold;   threshold;   threshold; \\n3309  threshold;   threshold;   threshold;   threshold; \\noutput: [      Surv prob  Surv prob SE  num at risk  num events\\nTime                                                  \\n51         0.95      0.048734         20.0         1.0\\n69          NaN           NaN          NaN         NaN\\n85          NaN           NaN          NaN         NaN\\n91          NaN           NaN          NaN         NaN\\n115         NaN           NaN          NaN         NaN\\n372         NaN           NaN          NaN         NaN\\n667         NaN           NaN          NaN         NaN\\n874         NaN           NaN          NaN         NaN\\n1039        NaN           NaN          NaN         NaN\\n1046        NaN           NaN          NaN         NaN\\n1281        NaN           NaN          NaN         NaN\\n1286        NaN           NaN          NaN         NaN\\n1326        NaN           NaN          NaN         NaN\\n1355        NaN           NaN          NaN         NaN\\n1626        NaN           NaN          NaN         NaN\\n1903        NaN           NaN          NaN         NaN\\n1914        NaN           NaN          NaN         NaN\\n2776        NaN           NaN          NaN         NaN\\n2851        NaN           NaN          NaN         NaN\\n3309        NaN           NaN          NaN         NaN]\\ntimestamp: 2024-01-30T14:10:00.984548\\ncomments: []\\nexception: \\n\\nuid: output_9\\nstatus: fail\\ntype: survival plot\\nproperties: {\\'method\\': \\'surv_func\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 76, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[1, 0], [1, 1], [1, 2], [1, 3], [2, 0], [2, 1], [2, 2], [2, 3], [3, 0], [3, 1], [3, 2], [3, 3], [4, 0], [4, 1], [4, 2], [4, 3], [5, 0], [5, 1], [5, 2], [5, 3], [6, 0], [6, 1], [6, 2], [6, 3], [7, 0], [7, 1], [7, 2], [7, 3], [8, 0], [8, 1], [8, 2], [8, 3], [9, 0], [9, 1], [9, 2], [9, 3], [10, 0], [10, 1], [10, 2], [10, 3], [11, 0], [11, 1], [11, 2], [11, 3], [12, 0], [12, 1], [12, 2], [12, 3], [13, 0], [13, 1], [13, 2], [13, 3], [14, 0], [14, 1], [14, 2], [14, 3], [15, 0], [15, 1], [15, 2], [15, 3], [16, 0], [16, 1], [16, 2], [16, 3], [17, 0], [17, 1], [17, 2], [17, 3], [18, 0], [18, 1], [18, 2], [18, 3], [19, 0], [19, 1], [19, 2], [19, 3]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_plot = acro.surv_func(\\nsummary: fail; threshold: 76 cells suppressed; \\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [\\'acro_artifacts\\\\\\\\kaplan-mier_0.png\\']\\ntimestamp: 2024-01-30T14:10:01.208677\\ncomments: []\\nexception: \\n\\n'"
+       "'uid: output_0\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'crosstab\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 4, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[2, 0], [2, 1], [2, 2], [4, 0]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.crosstab(\\nsummary: fail; threshold: 4 cells suppressed; \\noutcome: parents      great_pret  pretentious        usual\\nrecommend                                        \\nnot_recom            ok           ok           ok\\npriority             ok           ok           ok\\nrecommend   threshold;   threshold;   threshold; \\nspec_prior           ok           ok           ok\\nvery_recom  threshold;            ok           ok\\noutput: [parents     great_pret  pretentious   usual\\nrecommend                                  \\nnot_recom       1440.0       1440.0  1440.0\\npriority         858.0       1484.0  1924.0\\nrecommend          NaN          NaN     NaN\\nspec_prior      2022.0       1264.0   758.0\\nvery_recom         NaN        132.0   196.0]\\ntimestamp: 2024-03-04T21:21:07.616714\\ncomments: []\\nexception: \\n\\nuid: output_1\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'crosstab\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 5, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[2, 0], [2, 1], [2, 2], [2, 3], [4, 0]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.crosstab(\\nsummary: fail; threshold: 5 cells suppressed; \\noutcome: parents      great_pret  pretentious        usual          All\\nrecommend                                                     \\nnot_recom            ok           ok           ok           ok\\npriority             ok           ok           ok           ok\\nrecommend   threshold;   threshold;   threshold;   threshold; \\nspec_prior           ok           ok           ok           ok\\nvery_recom  threshold;            ok           ok           ok\\nAll                  ok           ok           ok           ok\\noutput: [parents     great_pret  pretentious  usual    All\\nrecommend                                        \\nnot_recom       1440.0         1440   1440   4320\\npriority         858.0         1484   1924   4266\\nspec_prior      2022.0         1264    758   4044\\nvery_recom         NaN          132    196    328\\nAll             4320.0         4320   4318  12958]\\ntimestamp: 2024-03-04T21:21:07.845655\\ncomments: []\\nexception: \\n\\nuid: output_2\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'crosstab\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': False, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 4, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[2, 0], [2, 1], [2, 2], [4, 0]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.crosstab(df.recommend, df.parents)\\nsummary: fail; threshold: 4 cells may need suppressing; \\noutcome: parents      great_pret  pretentious        usual\\nrecommend                                        \\nnot_recom            ok           ok           ok\\npriority             ok           ok           ok\\nrecommend   threshold;   threshold;   threshold; \\nspec_prior           ok           ok           ok\\nvery_recom  threshold;            ok           ok\\noutput: [parents     great_pret  pretentious  usual\\nrecommend                                 \\nnot_recom         1440         1440   1440\\npriority           858         1484   1924\\nrecommend            0            0      2\\nspec_prior        2022         1264    758\\nvery_recom           0          132    196]\\ntimestamp: 2024-03-04T21:21:07.967630\\ncomments: []\\nexception: \\n\\nuid: output_3\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'crosstab\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 1, \\'p-ratio\\': 4, \\'nk-rule\\': 4, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[2, 2]], \\'p-ratio\\': [[2, 0], [2, 1], [2, 2], [4, 0]], \\'nk-rule\\': [[2, 0], [2, 1], [2, 2], [4, 0]], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.crosstab(\\nsummary: fail; threshold: 1 cells suppressed; p-ratio: 4 cells suppressed; nk-rule: 4 cells suppressed; \\noutcome: parents             great_pret         pretentious  \\\\\\nrecommend                                            \\nnot_recom                   ok                  ok   \\npriority                    ok                  ok   \\nrecommend   p-ratio; nk-rule;   p-ratio; nk-rule;    \\nspec_prior                  ok                  ok   \\nvery_recom  p-ratio; nk-rule;                   ok   \\n\\nparents                             usual  \\nrecommend                                  \\nnot_recom                              ok  \\npriority                               ok  \\nrecommend   threshold; p-ratio; nk-rule;   \\nspec_prior                             ok  \\nvery_recom                             ok  \\noutput: [parents     great_pret  pretentious   usual\\nrecommend                                  \\nnot_recom       1440.0       1440.0  1440.0\\npriority         858.0       1484.0  1924.0\\nrecommend          NaN          NaN     NaN\\nspec_prior      2022.0       1264.0   758.0\\nvery_recom         NaN        132.0   196.0]\\ntimestamp: 2024-03-04T21:21:08.142362\\ncomments: []\\nexception: \\n\\nuid: output_4\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'crosstab\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 2, \\'p-ratio\\': 8, \\'nk-rule\\': 8, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[2, 2], [2, 5]], \\'p-ratio\\': [[2, 0], [2, 1], [2, 2], [2, 3], [2, 4], [2, 5], [4, 0], [4, 3]], \\'nk-rule\\': [[2, 0], [2, 1], [2, 2], [2, 3], [2, 4], [2, 5], [4, 0], [4, 3]], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.crosstab(\\nsummary: fail; threshold: 2 cells suppressed; p-ratio: 8 cells suppressed; nk-rule: 8 cells suppressed; \\noutcome:                   mode_aggfunc                      \\\\\\nparents             great_pret         pretentious   \\nrecommend                                            \\nnot_recom                   ok                  ok   \\npriority                    ok                  ok   \\nrecommend   p-ratio; nk-rule;   p-ratio; nk-rule;    \\nspec_prior                  ok                  ok   \\nvery_recom  p-ratio; nk-rule;                   ok   \\n\\n                                                         mean  \\\\\\nparents                             usual          great_pret   \\nrecommend                                                       \\nnot_recom                              ok                  ok   \\npriority                               ok                  ok   \\nrecommend   threshold; p-ratio; nk-rule;   p-ratio; nk-rule;    \\nspec_prior                             ok                  ok   \\nvery_recom                             ok  p-ratio; nk-rule;    \\n\\n                                                               \\nparents            pretentious                          usual  \\nrecommend                                                      \\nnot_recom                   ok                             ok  \\npriority                    ok                             ok  \\nrecommend   p-ratio; nk-rule;   threshold; p-ratio; nk-rule;   \\nspec_prior                  ok                             ok  \\nvery_recom                  ok                             ok  \\noutput: [           mode_aggfunc                         mean                      \\nparents      great_pret pretentious usual great_pret pretentious     usual\\nrecommend                                                                 \\nnot_recom           3.0         2.0   1.0   3.100694    3.143750  3.111806\\npriority            1.0         1.0   1.0   2.627040    3.022237  3.120062\\nrecommend           NaN         NaN   NaN        NaN         NaN       NaN\\nspec_prior          3.0         3.0   3.0   3.307122    3.336234  3.323219\\nvery_recom          NaN         1.0   1.0        NaN    2.227273  2.178571]\\ntimestamp: 2024-03-04T21:21:08.334715\\ncomments: []\\nexception: \\n\\nuid: output_5\\nstatus: pass\\ntype: table\\nproperties: {\\'method\\': \\'pivot_table\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 0, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: table = acro.pivot_table(\\nsummary: pass\\noutcome:                 mean      std\\n            children children\\nparents                      \\ngreat_pret        ok       ok\\npretentious       ok       ok\\nusual             ok       ok\\noutput: [                 mean       std\\n             children  children\\nparents                        \\ngreat_pret   3.103241  2.213116\\npretentious  3.130324  2.250447\\nusual        3.109259  2.216799]\\ntimestamp: 2024-03-04T21:21:08.485335\\ncomments: []\\nexception: \\n\\nuid: output_6\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'pivot_table\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 5, \\'p-ratio\\': 5, \\'nk-rule\\': 5, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[0, 2], [0, 4], [1, 2], [2, 2], [3, 2]], \\'p-ratio\\': [[0, 2], [0, 4], [1, 2], [2, 2], [3, 2]], \\'nk-rule\\': [[0, 2], [0, 4], [1, 2], [2, 2], [3, 2]], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.pivot_table(\\nsummary: fail; threshold: 5 cells suppressed; p-ratio: 5 cells suppressed; nk-rule: 5 cells suppressed; \\noutcome:              children                                                     \\\\\\nrecommend   not_recom priority                      recommend spec_prior   \\nparents                                                                    \\ngreat_pret         ok       ok  threshold; p-ratio; nk-rule;          ok   \\npretentious        ok       ok  threshold; p-ratio; nk-rule;          ok   \\nusual              ok       ok  threshold; p-ratio; nk-rule;          ok   \\nAll                ok       ok  threshold; p-ratio; nk-rule;          ok   \\n\\n                                                \\nrecommend                       very_recom All  \\nparents                                         \\ngreat_pret   threshold; p-ratio; nk-rule;   ok  \\npretentious                             ok  ok  \\nusual                                   ok  ok  \\nAll                                     ok  ok  \\noutput: [             children                                          \\nrecommend   not_recom  priority spec_prior very_recom       All\\nparents                                                        \\ngreat_pret   3.100694  2.627040   3.307122        NaN  3.103241\\npretentious  3.143750  3.022237   3.336234   2.227273  3.130324\\nusual        3.111806  3.120062   3.323219   2.178571  3.110236\\nAll          3.118750  2.986873   3.319238   2.198171  3.114601]\\ntimestamp: 2024-03-04T21:21:08.834120\\ncomments: []\\nexception: \\n\\nuid: output_7\\nstatus: pass\\ntype: regression\\nproperties: {\\'method\\': \\'ols\\', \\'dof\\': 12958.0}\\nsdc: {}\\ncommand: results = acro.ols(y, x)\\nsummary: pass; dof=12958.0 >= 10\\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [                          recommend           R-squared:       0.000\\nDep. Variable:                                                      \\nModel:                          OLS      Adj. R-squared:      0.0000\\nMethod:               Least Squares         F-statistic:      6.4170\\nDate:              Mon, 04 Mar 2024  Prob (F-statistic):      0.0113\\nTime:                      21:21:09      Log-Likelihood: -25124.0000\\nNo. Observations:             12960                 AIC:  50250.0000\\nDf Residuals:                 12958                 BIC:  50270.0000\\nDf Model:                         1                  NaN         NaN\\nCovariance Type:          nonrobust                  NaN         NaN,             coef  std err       t  P>|t|  [0.025  0.975]\\nconst     2.2341    0.025  87.965  0.000   2.184   2.284\\nchildren  0.0168    0.007   2.533  0.011   0.004   0.030,                 76735.931     Durbin-Watson:     2.883\\nOmnibus:                                              \\nProb(Omnibus):      0.000  Jarque-Bera (JB):  1742.843\\nSkew:              -0.485          Prob(JB):     0.000\\nKurtosis:           1.487          Cond. No.     6.890]\\ntimestamp: 2024-03-04T21:21:09.117190\\ncomments: []\\nexception: \\n\\nuid: output_8\\nstatus: pass\\ntype: regression\\nproperties: {\\'method\\': \\'olsr\\', \\'dof\\': 12958.0}\\nsdc: {}\\ncommand: results = acro.olsr(formula=\"recommend ~ children\", data=new_df)\\nsummary: pass; dof=12958.0 >= 10\\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [                          recommend           R-squared:       0.000\\nDep. Variable:                                                      \\nModel:                          OLS      Adj. R-squared:      0.0000\\nMethod:               Least Squares         F-statistic:      6.4170\\nDate:              Mon, 04 Mar 2024  Prob (F-statistic):      0.0113\\nTime:                      21:21:09      Log-Likelihood: -25124.0000\\nNo. Observations:             12960                 AIC:  50250.0000\\nDf Residuals:                 12958                 BIC:  50270.0000\\nDf Model:                         1                  NaN         NaN\\nCovariance Type:          nonrobust                  NaN         NaN,              coef  std err       t  P>|t|  [0.025  0.975]\\nIntercept  2.2341    0.025  87.965  0.000   2.184   2.284\\nchildren   0.0168    0.007   2.533  0.011   0.004   0.030,                 76735.931     Durbin-Watson:     2.883\\nOmnibus:                                              \\nProb(Omnibus):      0.000  Jarque-Bera (JB):  1742.843\\nSkew:              -0.485          Prob(JB):     0.000\\nKurtosis:           1.487          Cond. No.     6.890]\\ntimestamp: 2024-03-04T21:21:09.224540\\ncomments: []\\nexception: \\n\\nuid: output_9\\nstatus: pass\\ntype: regression\\nproperties: {\\'method\\': \\'probit\\', \\'dof\\': 12958.0}\\nsdc: {}\\ncommand: results = acro.probit(y, x)\\nsummary: pass; dof=12958.0 >= 10\\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [                           finance No. Observations:         12960\\nDep. Variable:                                                    \\nModel:                      Probit     Df Residuals:  12958.000000\\nMethod:                        MLE         Df Model:      1.000000\\nDate:             Mon, 04 Mar 2024    Pseudo R-squ.:      0.000001\\nTime:                     21:21:09   Log-Likelihood:  -8983.200000\\nconverged:                    True          LL-Null:  -8983.200000\\nCovariance Type:         nonrobust      LLR p-value:      0.883900,             coef  std err      z  P>|z|  [0.025  0.975]\\nconst    -0.0022    0.019 -0.119  0.905  -0.039   0.035\\nchildren  0.0007    0.005  0.146  0.884  -0.009   0.010]\\ntimestamp: 2024-03-04T21:21:09.358683\\ncomments: []\\nexception: \\n\\nuid: output_10\\nstatus: pass\\ntype: regression\\nproperties: {\\'method\\': \\'logit\\', \\'dof\\': 12958.0}\\nsdc: {}\\ncommand: results = acro.logit(y, x)\\nsummary: pass; dof=12958.0 >= 10\\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [                           finance No. Observations:         12960\\nDep. Variable:                                                    \\nModel:                       Logit     Df Residuals:  12958.000000\\nMethod:                        MLE         Df Model:      1.000000\\nDate:             Mon, 04 Mar 2024    Pseudo R-squ.:      0.000001\\nTime:                     21:21:09   Log-Likelihood:  -8983.200000\\nconverged:                    True          LL-Null:  -8983.200000\\nCovariance Type:         nonrobust      LLR p-value:      0.883900,             coef  std err      z  P>|z|  [0.025  0.975]\\nconst    -0.0036    0.030 -0.119  0.905  -0.063   0.056\\nchildren  0.0012    0.008  0.146  0.884  -0.014   0.017]\\ntimestamp: 2024-03-04T21:21:09.456005\\ncomments: []\\nexception: \\n\\nuid: output_11\\nstatus: fail\\ntype: table\\nproperties: {\\'method\\': \\'surv_func\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 76, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[1, 0], [1, 1], [1, 2], [1, 3], [2, 0], [2, 1], [2, 2], [2, 3], [3, 0], [3, 1], [3, 2], [3, 3], [4, 0], [4, 1], [4, 2], [4, 3], [5, 0], [5, 1], [5, 2], [5, 3], [6, 0], [6, 1], [6, 2], [6, 3], [7, 0], [7, 1], [7, 2], [7, 3], [8, 0], [8, 1], [8, 2], [8, 3], [9, 0], [9, 1], [9, 2], [9, 3], [10, 0], [10, 1], [10, 2], [10, 3], [11, 0], [11, 1], [11, 2], [11, 3], [12, 0], [12, 1], [12, 2], [12, 3], [13, 0], [13, 1], [13, 2], [13, 3], [14, 0], [14, 1], [14, 2], [14, 3], [15, 0], [15, 1], [15, 2], [15, 3], [16, 0], [16, 1], [16, 2], [16, 3], [17, 0], [17, 1], [17, 2], [17, 3], [18, 0], [18, 1], [18, 2], [18, 3], [19, 0], [19, 1], [19, 2], [19, 3]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_table = acro.surv_func(data.futime, data.death, output=\"table\")\\nsummary: fail; threshold: 76 cells suppressed; \\noutcome:         Surv prob Surv prob SE  num at risk   num events\\nTime                                                    \\n51             ok           ok           ok           ok\\n69    threshold;   threshold;   threshold;   threshold; \\n85    threshold;   threshold;   threshold;   threshold; \\n91    threshold;   threshold;   threshold;   threshold; \\n115   threshold;   threshold;   threshold;   threshold; \\n372   threshold;   threshold;   threshold;   threshold; \\n667   threshold;   threshold;   threshold;   threshold; \\n874   threshold;   threshold;   threshold;   threshold; \\n1039  threshold;   threshold;   threshold;   threshold; \\n1046  threshold;   threshold;   threshold;   threshold; \\n1281  threshold;   threshold;   threshold;   threshold; \\n1286  threshold;   threshold;   threshold;   threshold; \\n1326  threshold;   threshold;   threshold;   threshold; \\n1355  threshold;   threshold;   threshold;   threshold; \\n1626  threshold;   threshold;   threshold;   threshold; \\n1903  threshold;   threshold;   threshold;   threshold; \\n1914  threshold;   threshold;   threshold;   threshold; \\n2776  threshold;   threshold;   threshold;   threshold; \\n2851  threshold;   threshold;   threshold;   threshold; \\n3309  threshold;   threshold;   threshold;   threshold; \\noutput: [      Surv prob  Surv prob SE  num at risk  num events\\nTime                                                  \\n51         0.95      0.048734         20.0         1.0\\n69          NaN           NaN          NaN         NaN\\n85          NaN           NaN          NaN         NaN\\n91          NaN           NaN          NaN         NaN\\n115         NaN           NaN          NaN         NaN\\n372         NaN           NaN          NaN         NaN\\n667         NaN           NaN          NaN         NaN\\n874         NaN           NaN          NaN         NaN\\n1039        NaN           NaN          NaN         NaN\\n1046        NaN           NaN          NaN         NaN\\n1281        NaN           NaN          NaN         NaN\\n1286        NaN           NaN          NaN         NaN\\n1326        NaN           NaN          NaN         NaN\\n1355        NaN           NaN          NaN         NaN\\n1626        NaN           NaN          NaN         NaN\\n1903        NaN           NaN          NaN         NaN\\n1914        NaN           NaN          NaN         NaN\\n2776        NaN           NaN          NaN         NaN\\n2851        NaN           NaN          NaN         NaN\\n3309        NaN           NaN          NaN         NaN]\\ntimestamp: 2024-03-04T21:21:10.943849\\ncomments: []\\nexception: \\n\\nuid: output_12\\nstatus: fail\\ntype: survival plot\\nproperties: {\\'method\\': \\'surv_func\\'}\\nsdc: {\\'summary\\': {\\'suppressed\\': True, \\'negative\\': 0, \\'missing\\': 0, \\'threshold\\': 76, \\'p-ratio\\': 0, \\'nk-rule\\': 0, \\'all-values-are-same\\': 0}, \\'cells\\': {\\'negative\\': [], \\'missing\\': [], \\'threshold\\': [[1, 0], [1, 1], [1, 2], [1, 3], [2, 0], [2, 1], [2, 2], [2, 3], [3, 0], [3, 1], [3, 2], [3, 3], [4, 0], [4, 1], [4, 2], [4, 3], [5, 0], [5, 1], [5, 2], [5, 3], [6, 0], [6, 1], [6, 2], [6, 3], [7, 0], [7, 1], [7, 2], [7, 3], [8, 0], [8, 1], [8, 2], [8, 3], [9, 0], [9, 1], [9, 2], [9, 3], [10, 0], [10, 1], [10, 2], [10, 3], [11, 0], [11, 1], [11, 2], [11, 3], [12, 0], [12, 1], [12, 2], [12, 3], [13, 0], [13, 1], [13, 2], [13, 3], [14, 0], [14, 1], [14, 2], [14, 3], [15, 0], [15, 1], [15, 2], [15, 3], [16, 0], [16, 1], [16, 2], [16, 3], [17, 0], [17, 1], [17, 2], [17, 3], [18, 0], [18, 1], [18, 2], [18, 3], [19, 0], [19, 1], [19, 2], [19, 3]], \\'p-ratio\\': [], \\'nk-rule\\': [], \\'all-values-are-same\\': []}}\\ncommand: safe_plot = acro.surv_func(\\nsummary: fail; threshold: 76 cells suppressed; \\noutcome: Empty DataFrame\\nColumns: []\\nIndex: []\\noutput: [\\'acro_artifacts\\\\\\\\kaplan-mier_0.png\\']\\ntimestamp: 2024-03-04T21:21:11.236799\\ncomments: []\\nexception: \\n\\n'"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1616,7 +1885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "id": "e4ee985e",
    "metadata": {
     "slideshow": {
@@ -1652,7 +1921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "id": "b9d0b9ac",
    "metadata": {
     "slideshow": {
@@ -1688,7 +1957,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "id": "8e21f7b0",
    "metadata": {
     "slideshow": {
@@ -1725,7 +1994,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "id": "1e8000a1",
    "metadata": {
     "slideshow": {
@@ -1737,7 +2006,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:records:add_custom(): output_10\n"
+      "INFO:acro:records:add_custom(): output_13\n"
      ]
     }
    ],
@@ -1765,7 +2034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "id": "f941aca2",
    "metadata": {
     "slideshow": {
@@ -1777,170 +2046,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:records:\n",
-      "uid: output_1\n",
-      "status: fail\n",
-      "type: table\n",
-      "properties: {'method': 'crosstab'}\n",
-      "sdc: {'summary': {'suppressed': False, 'negative': 0, 'missing': 0, 'threshold': 4, 'p-ratio': 0, 'nk-rule': 0, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[2, 0], [2, 1], [2, 2], [4, 0]], 'p-ratio': [], 'nk-rule': [], 'all-values-are-same': []}}\n",
-      "command: safe_table = acro.crosstab(df.recommend, df.parents)\n",
-      "summary: fail; threshold: 4 cells may need suppressing; \n",
-      "outcome: parents      great_pret  pretentious        usual\n",
-      "recommend                                        \n",
-      "not_recom            ok           ok           ok\n",
-      "priority             ok           ok           ok\n",
-      "recommend   threshold;   threshold;   threshold; \n",
-      "spec_prior           ok           ok           ok\n",
-      "very_recom  threshold;            ok           ok\n",
-      "output: [parents     great_pret  pretentious  usual\n",
-      "recommend                                 \n",
-      "not_recom         1440         1440   1440\n",
-      "priority           858         1484   1924\n",
-      "recommend            0            0      2\n",
-      "spec_prior        2022         1264    758\n",
-      "very_recom           0          132    196]\n",
-      "timestamp: 2024-01-30T14:09:59.381804\n",
-      "comments: ['Please let me have this data.', '6 cells were suppressed in this table']\n",
-      "exception: \n",
-      "\n",
-      "The status of the record above is: fail.\n",
-      "Please explain why an exception should be granted.\n",
-      "\n",
-      "INFO:acro:records:\n",
-      "uid: output_8\n",
-      "status: fail\n",
-      "type: table\n",
-      "properties: {'method': 'surv_func'}\n",
-      "sdc: {'summary': {'suppressed': True, 'negative': 0, 'missing': 0, 'threshold': 76, 'p-ratio': 0, 'nk-rule': 0, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[1, 0], [1, 1], [1, 2], [1, 3], [2, 0], [2, 1], [2, 2], [2, 3], [3, 0], [3, 1], [3, 2], [3, 3], [4, 0], [4, 1], [4, 2], [4, 3], [5, 0], [5, 1], [5, 2], [5, 3], [6, 0], [6, 1], [6, 2], [6, 3], [7, 0], [7, 1], [7, 2], [7, 3], [8, 0], [8, 1], [8, 2], [8, 3], [9, 0], [9, 1], [9, 2], [9, 3], [10, 0], [10, 1], [10, 2], [10, 3], [11, 0], [11, 1], [11, 2], [11, 3], [12, 0], [12, 1], [12, 2], [12, 3], [13, 0], [13, 1], [13, 2], [13, 3], [14, 0], [14, 1], [14, 2], [14, 3], [15, 0], [15, 1], [15, 2], [15, 3], [16, 0], [16, 1], [16, 2], [16, 3], [17, 0], [17, 1], [17, 2], [17, 3], [18, 0], [18, 1], [18, 2], [18, 3], [19, 0], [19, 1], [19, 2], [19, 3]], 'p-ratio': [], 'nk-rule': [], 'all-values-are-same': []}}\n",
-      "command: safe_table = acro.surv_func(data.futime, data.death, output=\"table\")\n",
-      "summary: fail; threshold: 76 cells suppressed; \n",
-      "outcome:         Surv prob Surv prob SE  num at risk   num events\n",
-      "Time                                                    \n",
-      "51             ok           ok           ok           ok\n",
-      "69    threshold;   threshold;   threshold;   threshold; \n",
-      "85    threshold;   threshold;   threshold;   threshold; \n",
-      "91    threshold;   threshold;   threshold;   threshold; \n",
-      "115   threshold;   threshold;   threshold;   threshold; \n",
-      "372   threshold;   threshold;   threshold;   threshold; \n",
-      "667   threshold;   threshold;   threshold;   threshold; \n",
-      "874   threshold;   threshold;   threshold;   threshold; \n",
-      "1039  threshold;   threshold;   threshold;   threshold; \n",
-      "1046  threshold;   threshold;   threshold;   threshold; \n",
-      "1281  threshold;   threshold;   threshold;   threshold; \n",
-      "1286  threshold;   threshold;   threshold;   threshold; \n",
-      "1326  threshold;   threshold;   threshold;   threshold; \n",
-      "1355  threshold;   threshold;   threshold;   threshold; \n",
-      "1626  threshold;   threshold;   threshold;   threshold; \n",
-      "1903  threshold;   threshold;   threshold;   threshold; \n",
-      "1914  threshold;   threshold;   threshold;   threshold; \n",
-      "2776  threshold;   threshold;   threshold;   threshold; \n",
-      "2851  threshold;   threshold;   threshold;   threshold; \n",
-      "3309  threshold;   threshold;   threshold;   threshold; \n",
-      "output: [      Surv prob  Surv prob SE  num at risk  num events\n",
-      "Time                                                  \n",
-      "51         0.95      0.048734         20.0         1.0\n",
-      "69          NaN           NaN          NaN         NaN\n",
-      "85          NaN           NaN          NaN         NaN\n",
-      "91          NaN           NaN          NaN         NaN\n",
-      "115         NaN           NaN          NaN         NaN\n",
-      "372         NaN           NaN          NaN         NaN\n",
-      "667         NaN           NaN          NaN         NaN\n",
-      "874         NaN           NaN          NaN         NaN\n",
-      "1039        NaN           NaN          NaN         NaN\n",
-      "1046        NaN           NaN          NaN         NaN\n",
-      "1281        NaN           NaN          NaN         NaN\n",
-      "1286        NaN           NaN          NaN         NaN\n",
-      "1326        NaN           NaN          NaN         NaN\n",
-      "1355        NaN           NaN          NaN         NaN\n",
-      "1626        NaN           NaN          NaN         NaN\n",
-      "1903        NaN           NaN          NaN         NaN\n",
-      "1914        NaN           NaN          NaN         NaN\n",
-      "2776        NaN           NaN          NaN         NaN\n",
-      "2851        NaN           NaN          NaN         NaN\n",
-      "3309        NaN           NaN          NaN         NaN]\n",
-      "timestamp: 2024-01-30T14:10:00.984548\n",
-      "comments: []\n",
-      "exception: \n",
-      "\n",
-      "The status of the record above is: fail.\n",
-      "Please explain why an exception should be granted.\n",
-      "\n",
-      "INFO:acro:records:\n",
-      "uid: output_9\n",
-      "status: fail\n",
-      "type: survival plot\n",
-      "properties: {'method': 'surv_func'}\n",
-      "sdc: {'summary': {'suppressed': True, 'negative': 0, 'missing': 0, 'threshold': 76, 'p-ratio': 0, 'nk-rule': 0, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[1, 0], [1, 1], [1, 2], [1, 3], [2, 0], [2, 1], [2, 2], [2, 3], [3, 0], [3, 1], [3, 2], [3, 3], [4, 0], [4, 1], [4, 2], [4, 3], [5, 0], [5, 1], [5, 2], [5, 3], [6, 0], [6, 1], [6, 2], [6, 3], [7, 0], [7, 1], [7, 2], [7, 3], [8, 0], [8, 1], [8, 2], [8, 3], [9, 0], [9, 1], [9, 2], [9, 3], [10, 0], [10, 1], [10, 2], [10, 3], [11, 0], [11, 1], [11, 2], [11, 3], [12, 0], [12, 1], [12, 2], [12, 3], [13, 0], [13, 1], [13, 2], [13, 3], [14, 0], [14, 1], [14, 2], [14, 3], [15, 0], [15, 1], [15, 2], [15, 3], [16, 0], [16, 1], [16, 2], [16, 3], [17, 0], [17, 1], [17, 2], [17, 3], [18, 0], [18, 1], [18, 2], [18, 3], [19, 0], [19, 1], [19, 2], [19, 3]], 'p-ratio': [], 'nk-rule': [], 'all-values-are-same': []}}\n",
-      "command: safe_plot = acro.surv_func(\n",
-      "summary: fail; threshold: 76 cells suppressed; \n",
-      "outcome: Empty DataFrame\n",
-      "Columns: []\n",
-      "Index: []\n",
-      "output: ['acro_artifacts\\\\kaplan-mier_0.png']\n",
-      "timestamp: 2024-01-30T14:10:01.208677\n",
-      "comments: []\n",
-      "exception: \n",
-      "\n",
-      "The status of the record above is: fail.\n",
-      "Please explain why an exception should be granted.\n",
-      "\n",
-      "INFO:acro:records:\n",
-      "uid: pivot_table\n",
-      "status: fail\n",
-      "type: table\n",
-      "properties: {'method': 'crosstab'}\n",
-      "sdc: {'summary': {'suppressed': True, 'negative': 0, 'missing': 0, 'threshold': 1, 'p-ratio': 4, 'nk-rule': 4, 'all-values-are-same': 0}, 'cells': {'negative': [], 'missing': [], 'threshold': [[2, 2]], 'p-ratio': [[2, 0], [2, 1], [2, 2], [4, 0]], 'nk-rule': [[2, 0], [2, 1], [2, 2], [4, 0]], 'all-values-are-same': []}}\n",
-      "command: safe_table = acro.crosstab(df.recommend, df.parents, values=df.children, aggfunc=\"mean\")\n",
-      "summary: fail; threshold: 1 cells suppressed; p-ratio: 4 cells suppressed; nk-rule: 4 cells suppressed; \n",
-      "outcome: parents             great_pret         pretentious  \\\n",
-      "recommend                                            \n",
-      "not_recom                   ok                  ok   \n",
-      "priority                    ok                  ok   \n",
-      "recommend   p-ratio; nk-rule;   p-ratio; nk-rule;    \n",
-      "spec_prior                  ok                  ok   \n",
-      "very_recom  p-ratio; nk-rule;                   ok   \n",
-      "\n",
-      "parents                             usual  \n",
-      "recommend                                  \n",
-      "not_recom                              ok  \n",
-      "priority                               ok  \n",
-      "recommend   threshold; p-ratio; nk-rule;   \n",
-      "spec_prior                             ok  \n",
-      "very_recom                             ok  \n",
-      "output: [parents     great_pret  pretentious     usual\n",
-      "recommend                                    \n",
-      "not_recom     3.147222     3.097917  3.093750\n",
-      "priority      2.636364     3.000674  3.075364\n",
-      "recommend          NaN          NaN       NaN\n",
-      "spec_prior    3.345697     3.332278  3.317942\n",
-      "very_recom         NaN     2.227273  2.229592]\n",
-      "timestamp: 2024-01-30T14:09:59.519976\n",
-      "comments: []\n",
-      "exception: \n",
-      "\n",
-      "The status of the record above is: fail.\n",
-      "Please explain why an exception should be granted.\n",
-      "\n",
-      "INFO:acro:records:\n",
-      "uid: output_10\n",
-      "status: review\n",
-      "type: custom\n",
-      "properties: {}\n",
-      "sdc: {}\n",
-      "command: custom\n",
-      "summary: review\n",
-      "outcome: Empty DataFrame\n",
-      "Columns: []\n",
-      "Index: []\n",
-      "output: ['XandY.jpeg']\n",
-      "timestamp: 2024-01-30T14:10:01.468365\n",
-      "comments: ['This output is an image showing the relationship between X and Y']\n",
-      "exception: \n",
-      "\n",
-      "The status of the record above is: review.\n",
-      "Please explain why an exception should be granted.\n",
-      "\n",
-      "INFO:acro:records:outputs written to: NURSERY\n"
+      "WARNING:acro:Results file can not be created. Directory NURSERY already exists. Please choose a different directory name.\n"
      ]
     }
    ],
@@ -1959,7 +2065,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "fdea993a",
    "metadata": {},
    "outputs": [
@@ -1967,37 +2073,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:acro:version: 0.4.3\n",
-      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False, 'survival_safe_threshold': 10, 'zeros_are_disclosive': True}\n",
+      "INFO:acro:version: 0.4.5\n",
+      "INFO:acro:config: {'safe_threshold': 10, 'safe_dof_threshold': 10, 'safe_nk_n': 2, 'safe_nk_k': 0.9, 'safe_pratio_p': 0.1, 'check_missing_values': False, 'survival_safe_threshold': 10, 'zeros_are_disclosive': True, 'unsupported_filetypes': ['.gph', '.svg']}\n",
       "INFO:acro:automatic suppression: False\n",
       "INFO:acro:records:add_custom(): output_0\n",
       "INFO:acro:records:rename_output(): output_0 renamed to crosstab.pkl\n",
-      "INFO:acro:records:\n",
-      "uid: crosstab.pkl\n",
-      "status: review\n",
-      "type: custom\n",
-      "properties: {}\n",
-      "sdc: {}\n",
-      "command: custom\n",
-      "summary: review\n",
-      "outcome: Empty DataFrame\n",
-      "Columns: []\n",
-      "Index: []\n",
-      "output: ['test_add_to_acro\\\\crosstab.pkl']\n",
-      "timestamp: 2024-01-30T14:10:05.475682\n",
-      "comments: ['']\n",
-      "exception: \n",
-      "\n",
-      "The status of the record above is: review.\n",
-      "Please explain why an exception should be granted.\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:acro:records:outputs written to: SDC_results\n"
+      "WARNING:acro:Results file can not be created. Directory SDC_results already exists. Please choose a different directory name.\n"
      ]
     }
    ],

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -732,6 +732,7 @@ def test_crosstab_with_manual_totals_with_suppression(data, acro):
     total_cols = output.output[0].loc[2010:2015, "All"].sum()
     assert 870 == total_cols == total_rows == output.output[0]["All"].iat[6]
     assert "R/G" in output.output[0].columns
+    assert np.isnan(output.output[0]["R/G"].iat[0])
 
 
 def test_crosstab_with_manual_totals_with_suppression_hierarchical(data, acro):
@@ -755,6 +756,7 @@ def test_crosstab_with_manual_totals_with_suppression_hierarchical(data, acro):
     ]
     assert total_cols == total_rows == output.output[0]["All"].iat[12] == 852
     assert ("G", "dead") in output.output[0].columns
+    assert np.isnan(output.output[0][("G", "dead")].iat[0])
 
 
 def test_crosstab_with_manual_totals_with_suppression_with_aggfunc_mean(data, acro):
@@ -773,6 +775,7 @@ def test_crosstab_with_manual_totals_with_suppression_with_aggfunc_mean(data, ac
     assert 8689780 == round(output.output[0]["All"].iat[0])
     assert 5425170 == round(output.output[0]["All"].iat[6])
     assert "R/G" in output.output[0].columns
+    assert np.isnan(output.output[0]["R/G"].iat[0])
 
 
 def test_hierarchical_crosstab_with_manual_totals_with_mean(data, acro):
@@ -791,6 +794,7 @@ def test_hierarchical_crosstab_with_manual_totals_with_mean(data, acro):
     assert 1385162 == round(output.output[0]["All"].iat[0])
     assert 5434959 == round(output.output[0]["All"].iat[12])
     assert ("G", "Dead in 2015") in output.output[0].columns
+    assert np.isnan(output.output[0][("G", "Dead in 2015")].iat[0])
 
 
 def test_crosstab_with_manual_totals_with_suppression_with_aggfunc_std(
@@ -809,6 +813,7 @@ def test_crosstab_with_manual_totals_with_suppression_with_aggfunc_std(
     )
     output = acro.results.get_index(0)
     assert "All" not in output.output[0].columns
+    assert np.isnan(output.output[0]["R/G"].iat[0])
     assert (
         "The margins with the std agg func can not be calculated. "
         "Please set the show_suppressed to false to calculate it." in caplog.text


### PR DESCRIPTION
This is to fix the crosstab. An issue was raised that when suppression is true and margins is true the cells that violate the rules are not being suppressed.

The problem stemmed from the process of recalculating totals. Initially, the function applied a list of boolean conditions for each true cell in the suppression masks to the dataset and then generated the crosstab. However, it missed applying suppression after calculating the crosstab. This was added in this PR.