### PR TITLE
add basic ruff formating/linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
 
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -26,7 +26,7 @@ repos:
 
   # Check for spelling
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         args: ["-L", "tre"]
@@ -39,7 +39,7 @@ repos:
 
   # Ruff, the Python auto-correcting linter/formatter written in Rust
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.4.7
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
@@ -47,7 +47,7 @@ repos:
 
   # Check types with mypy
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: mypy
         args: ["--ignore-missing-imports", "--follow-imports", "skip", "--check-untyped-defs"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
 
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -26,7 +26,7 @@ repos:
 
   # Check for spelling
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.2.6
     hooks:
       - id: codespell
         args: ["-L", "tre"]
@@ -37,54 +37,17 @@ repos:
                 .*\.html
             )$
 
-  # Upgrade old Python syntax
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+  # Ruff, the Python auto-correcting linter/formatter written in Rust
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.3
     hooks:
-      - id: pyupgrade
-        args: [--py310-plus]
-
-  # Autoremoves unused imports
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.3.1
-    hooks:
-      - id: autoflake
-
-  # Sort includes
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
-  # Format docstrings
-  - repo: https://github.com/DanielNoord/pydocstringformatter
-    rev: "v0.7.3"
-    hooks:
-      - id: pydocstringformatter
-        args: ["--style=numpydoc"]
-
-  # Black format Python and notebooks
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black-jupyter
-
-  # Check Python with flake8
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        args:
-          - --max-line-length=95
-          - --exclude=__init__.py
-          - --ignore=E203,W503
-        additional_dependencies: [flake8-bugbear, pep8-naming]
-        exclude: "docs"
+      - id: ruff
+        args: ["--fix", "--show-fixes"]
+      - id: ruff-format
 
   # Check types with mypy
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         args: ["--ignore-missing-imports", "--follow-imports", "skip", "--check-untyped-defs"]

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -36,9 +36,14 @@ class ACRO(Tables, Regression):
     Examples
     --------
     >>> acro = ACRO()
-    >>> results = acro.ols(y, x)
+    >>> results = acro.ols(
+    ...     y, x
+    ... )
     >>> results.summary()
-    >>> acro.finalise("MYFOLDER", "json")
+    >>> acro.finalise(
+    ...     "MYFOLDER",
+    ...     "json",
+    ... )
     """
 
     def __init__(self, config: str = "default", suppress: bool = False) -> None:

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -444,16 +444,14 @@ class Tables:
         """
         logger.debug("surv_func()")
         command: str = utils.get_command("surv_func()", stack())
-        survival_func: DataFrame = (
-            sm.SurvfuncRight(  # pylint: disable=too-many-function-args
-                time,
-                status,
-                entry,
-                title,
-                freq_weights,
-                exog,
-                bw_factor,
-            )
+        survival_func: DataFrame = sm.SurvfuncRight(  # pylint: disable=too-many-function-args
+            time,
+            status,
+            entry,
+            title,
+            freq_weights,
+            exog,
+            bw_factor,
         )
         masks = {}
         survival_table = survival_func.summary()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,58 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+indent-width = 4
+line-length = 88
+target-version = "py39"
+
+lint.select = [
+#  "ANN", # flake8-annotations
+  "ARG", # flake8-unused-arguments
+  "B",   # flake8-bugbear
+#  "C4",  # flake8-comprehensions
+  "C90", # mccabe
+#  "D",   # pydocstyle
+#  "DTZ", # flake8-datetimez
+#  "E",   # pycodestyle
+#  "ERA", # eradicate
+  "F",   # Pyflakes
+  "I",   # isort
+  "N",   # pep8-naming
+#  "PD",  # pandas-vet
+#  "PGH", # pygrep-hooks
+  "PLC", # Pylint
+  "PLE", # Pylint
+#  "PLR", # Pylint
+#  "PLW", # Pylint
+#  "PT",  # flake8-pytest-style
+  "Q",   # flake8-quotes
+#  "RET", # flake8-return
+#  "S",   # flake8-bandit
+#  "SIM", # flake8-simplify
+#  "T20", # flake8-print
+  "TID", # flake8-tidy-imports
+  "W",   # pycodestyle
+]
+
+exclude = [
+  "__init__.py",
+]
+
+lint.ignore = [
+#  "ANN101", # missing-type-self
+#  "D203",   # blank line required before class docstring
+#  "D213",   # multi-line-summary-second-line
+#  "S301",   # unsafe pickle
+]
+
+[tool.ruff.lint.pep8-naming]
+extend-ignore-names = ["X", "X_train", "X_predict"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 20


### PR DESCRIPTION
Adds basic [Ruff](https://github.com/astral-sh/ruff) formatter/linter to pre-commit.

Ruff can replace most of the Python tools we use: source formatting, linting, etc.