### PR TITLE
fix codecov reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install
         run: |
-          python -m pip install --upgrade pip
-          pip install pylint pytest pytest-cov
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install --upgrade pip
+          pip install .[test]
 
-      - name: pytest and report coverage
+      - name: Generate coverage report
         run: |
           pytest --cov=./ --cov-report=xml
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,10 @@ doc =
     sphinx-rtd-theme==1.0.0
     statsmodels==0.13.2
 
+test =
+    pytest
+    pytest-cov
+
 [options.package_data]
 acro = default.yaml
 


### PR DESCRIPTION
Codecov.io now requires a secret token to upload reports. This PR fixes code coverage reporting.