### PR TITLE
cap numpy at <2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ packages = find:
 install_requires =
     lxml
     matplotlib
-    numpy
+    numpy<2.0.0
     openpyxl
     pandas~=1.5.0
     PyYAML


### PR DESCRIPTION
Limit numpy dependency to avoid using =>2.0.0