### PR TITLE
add support for pandas version 2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install
         run: |
-          python -m pip install --upgrade pip
-          pip install pylint pytest pytest-cov
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install --upgrade pip
+          pip install .[test]
+          pip install pylint
 
       - name: pylint
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests_python313.yml
+++ b/.github/workflows/tests_python313.yml
@@ -1,5 +1,5 @@
 ---
-name: Test Python312
+name: Test Python313
 
 on: workflow_dispatch
 
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.4.7 (Oct 22, 2024)
+
+Changes:
+*   Add support for Pandas version 2 ([#237](https://github.com/AI-SDC/ACRO/pull/237))
+
 ## Version 0.4.6 (Jun 25, 2024)
 
 Changes:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 title: ACRO
-version: 0.4.6
-doi: 10.5281/zenodo.12535291
-date-released: 2024-06-25
+version: 0.4.7
+doi:
+date-released: 2024-10-22
 license: MIT
 repository-code: https://github.com/AI-SDC/ACRO
 languages:
@@ -13,6 +13,7 @@ keywords:
   - privacy
   - privacy tools
   - statistical disclosure control
+  - statistical software
 authors:
   - family-names: Preen
     given-names: Richard John

--- a/README.md
+++ b/README.md
@@ -8,22 +8,16 @@
 
 This repository holds the Python ACRO package. An R wrapper package is available: [ACRO-R](https://github.com/AI-SDC/ACRO-R).
 
-ACRO (Automatic Checking of Research Outputs) is an open source
-tool for automating the statistical disclosure control (SDC) of research
-outputs. ACRO assists researchers and output checkers by distinguishing between
-research output that is safe to publish, output that requires further analysis,
-and output that cannot be published because of substantial disclosure risk.
+A GUI for viewing and approving outputs is also available: [SACRO-Viewer](https://github.com/AI-SDC/SACRO-Viewer)
 
-It does this by providing a light-weight 'skin' that sits over well-known
-analysis tools, in a variety of languages researchers might use. This adds
-functionality to:
+ACRO (Automatic Checking of Research Outputs) is an open source tool for automating the [statistical disclosure control](https://en.wikipedia.org/wiki/Statistical_disclosure_control) (SDC) of research outputs. ACRO assists researchers and output checkers by distinguishing between research output that is safe to publish, output that requires further analysis, and output that cannot be published because of a substantial risk of disclosing private data.
 
-*   identify potentially disclosive outputs against a range of commonly used
-    disclosure tests;
+It does this by providing a lightweight 'skin' that sits over well-known analysis tools, in a variety of languages researchers might use. This adds functionality to:
+
+*   identify potentially disclosive outputs against a range of commonly used disclosure tests;
 *   suppress outputs where required;
 *   report reasons for suppression;
-*   produce simple summary documents TRE staff can use to streamline their
-    workflow.
+*   produce simple summary documents TRE staff can use to streamline their workflow.
 
 ![ACRO workflow and architecture schematic](docs/schematic.png)
 
@@ -37,15 +31,16 @@ If installed in this way, the example [notebooks](notebooks) and the [data](data
 $ pip install acro
 ```
 
-#### Notes for Python 3.12
+#### Notes for Python 3.13
 
-ACRO currently depends on an older version of Pandas (~1.5.0) for which no pre-compiled wheels are available within pip for Python 3.12. Therefore, in this scenario, Pandas must be built from source. This requires the installation of a C++ compiler before pip installing acro.
+ACRO currently depends on numpy version 1.x.x for which no pre-compiled wheels are available within pip for Python 3.13. Therefore, in this scenario, numpy must be built from source. This requires the installation of a C++ compiler before pip installing acro.
 
-For Windows, [Microsoft Visual Studio](https://visualstudio.microsoft.com/downloads/) and the [C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) will likely need to be installed first.
+For Windows, the [Microsoft Visual Studio C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) will likely need to be installed first.
 
 ### Examples
 
 See the example notebooks for:
+
 * [Python charities dataset](notebooks/test.ipynb)
 * [Python nursery dataset](notebooks/test-nursery.ipynb)
 * [R charities dataset](https://ai-sdc.github.io/ACRO/_static/test.nb.html)

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -1512,6 +1512,9 @@ def crosstab_with_totals(  # pylint: disable=too-many-arguments,too-many-locals
                 normalize=normalize,
             )
 
+            if table.empty:
+                raise ValueError("empty table")
+
             table, _ = delete_empty_rows_columns(table)
             masks = create_crosstab_masks(
                 index_new,

--- a/acro/version.py
+++ b/acro/version.py
@@ -1,3 +1,3 @@
 """ACRO version number."""
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,7 @@ from acro.version import __version__
 # -- Project information -----------------------------------------------------
 
 project = "ACRO"
-copyright = "2023, ACRO Project Team"
+copyright = "2024, ACRO Project Team"
 author = "ACRO Project Team"
 release = __version__
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-lxml==4.9.1
-matplotlib==3.7.2
-numpy==1.23.1
-openpyxl==3.0.10
-pandas==1.5.0
-PyYAML==6.0
-statsmodels==0.13.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ keywords =
     privacy
     privacy-tools
     statistical-disclosure-control
+    statistical-software
 project_urls =
     Changelog = https://github.com/AI-SDC/ACRO/CHANGELOG.md
     Documentation = https://github.com/AI-SDC/ACRO/wiki
@@ -45,7 +46,7 @@ install_requires =
     matplotlib
     numpy<2.0.0
     openpyxl
-    pandas>1.5.0,<2.3
+    pandas>=1.5.0,<2.3
     PyYAML
     statsmodels
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = acro
-version = 0.4.6
+version = 0.4.7
 description = ACRO: Tools for the Automatic Checking of Research Outputs
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -10,16 +10,16 @@ maintainer_email = james.smith@uwe.ac.uk
 license = MIT
 license_files = LICENSE.md
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     License :: OSI Approved :: MIT License
     Natural Language :: English
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Information Analysis
     Operating System :: OS Independent
@@ -36,7 +36,7 @@ project_urls =
     Discussions = https://github.com/AI-SDC/ACRO/discussions
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 zip_safe = False
 include_package_data = True
 packages = find:
@@ -45,7 +45,7 @@ install_requires =
     matplotlib
     numpy<2.0.0
     openpyxl
-    pandas~=1.5.0
+    pandas>1.5.0,<2.3
     PyYAML
     statsmodels
 

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -379,7 +379,12 @@ def test_finalise_json(data, acro):
     assert orig.summary == read.summary
     assert orig.comments == read.comments
     assert orig.timestamp == read.timestamp
-    assert (orig.output[0].reset_index()).equals(read.output[0])
+    # check SDC outcome DataFrame
+    orig_df = orig.output[0].reset_index()
+    read_df = read.output[0]
+    pd.testing.assert_frame_equal(
+        orig_df, read_df, check_names=False, check_dtype=False
+    )
     # test reading JSON
     with open(os.path.normpath(f"{PATH}/results.json"), encoding="utf-8") as file:
         json_data = json.load(file)


### PR DESCRIPTION
Some (minor) changes for compatibility with Pandas >=2.

Resolves #149 

* No functional changes were required that modify existing behaviour;
* Changes dependencies to allow pandas v2:  `pandas>1.5.0,<2.3`
  - This means that pandas no longer has to be built from source for Python 3.12 (more seamless install)
* Drops Python 3.8, which is end of life
* Adds Python 3.13 (but see notes)
* CI confirms Python 3.9--3.12 all work on ubuntu, Windows, and macOS;
* CI confirms Python 3.13 works on ubuntu and macOS; however pytest fails on Windows with `Windows fatal exception: access violation` probably due to numpy (see below); so this has been put in a separate CI runner 
* Python 3.13 manual installation/tests in a Windows VM: numpy was able to be built from source and the tests all completed fine with the exception of some error about tkinter, which seems to be a generic issue with running tkinter in virtual environments with Python 3.13
* Test notebook produces same output with Pandas 1.5.3 and 2.2.3
* Bumps acro version to v0.4.7

**Note:**

Numpy only has wheels for Python 3.13 for version >=2.1 so it has to be built from source (requiring C++ build tools) for the version acro currently uses: 1.26.4 since we do not support version 2 yet. The note in the README has been updated to reflect this.