### PR TITLE
NumPy 2.0 compatibility fixes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,6 +30,10 @@ authors:
     given-names: Simon
     affiliation: University of Oxford
     orcid: https://orcid.org/0000-0001-9890-3619
+  - family-names: Migenda
+    given-names: Jost
+    affiliation: King’s College London
+    orcid: https://orcid.org/0000-0002-5350-8049
 identifiers:
   - type: doi
     value: 10.5281/zenodo.7273903

--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ If installed in this way, the example [notebooks](notebooks) and the [data](data
 $ pip install acro
 ```
 
-#### Notes for Python 3.13
-
-ACRO currently depends on numpy version 1.x.x for which no pre-compiled wheels are available within pip for Python 3.13. Therefore, in this scenario, numpy must be built from source. This requires the installation of a C++ compiler before pip installing acro.
-
-For Windows, the [Microsoft Visual Studio C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) will likely need to be installed first.
-
 ### Examples
 
 See the example notebooks for:

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -1163,7 +1163,7 @@ def apply_suppression(
     else:
         for name, mask in masks.items():
             try:
-                safe_df[mask.values] = np.NaN
+                safe_df[mask.values] = np.nan
                 tmp_df = DataFrame().reindex_like(outcome_df)
                 tmp_df.fillna("", inplace=True)
                 tmp_df[mask.values] = name + "; "

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ packages = find:
 install_requires =
     lxml
     matplotlib
-    numpy<2.0.0
+    numpy
     openpyxl
     pandas>=1.5.0,<2.3
     PyYAML

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -453,7 +453,7 @@ def test_custom_output(acro):
 def test_missing(data, acro, monkeypatch):
     """Pivot table and Crosstab with negative values."""
     acro_tables.CHECK_MISSING_VALUES = True
-    data.loc[0:10, "inc_grants"] = np.NaN
+    data.loc[0:10, "inc_grants"] = np.nan
     _ = acro.crosstab(
         data.year, data.grant_type, values=data.inc_grants, aggfunc="mean"
     )
@@ -476,7 +476,7 @@ def test_missing(data, acro, monkeypatch):
 def test_suppression_error(caplog):
     """Apply suppression type error test."""
     table_data = {"col1": [1, 2], "col2": [3, 4]}
-    mask_data = {"col1": [np.NaN, True], "col2": [True, True]}
+    mask_data = {"col1": [np.nan, True], "col2": [True, True]}
     table = pd.DataFrame(data=table_data)
     masks = {"test": pd.DataFrame(data=mask_data)}
     acro_tables.apply_suppression(table, masks)


### PR DESCRIPTION
Changes a few occurrences of `np.NaN` to `np.nan`. This remains fully compatible with NumPy 1.x ([where `np.NaN` is an alias of `np.nan`](https://numpy.org/doc/1.26/reference/constants.html#numpy.NaN)), but is necessary for compatibility with NumPy 2.x where all aliases of `np.nan` have been removed to simplify the API.