### PR TITLE
Prepare for v0.4.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.4.8 (Jan 29, 2025)
+
+*   Add support for Numpy version 2 ([#247](https://github.com/AI-SDC/ACRO/pull/247))
+
 ## Version 0.4.7 (Oct 22, 2024)
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.4.8 (Jan 29, 2025)
 
+Changes:
 *   Add support for Numpy version 2 ([#247](https://github.com/AI-SDC/ACRO/pull/247))
 
 ## Version 0.4.7 (Oct 22, 2024)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 title: ACRO
-version: 0.4.7
-doi: 10.5281/zenodo.13970111
-date-released: 2024-10-22
+version: 0.4.8
+doi:
+date-released: 2025-01-29
 license: MIT
 repository-code: https://github.com/AI-SDC/ACRO
 languages:

--- a/acro/version.py
+++ b/acro/version.py
@@ -1,3 +1,3 @@
 """ACRO version number."""
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = acro
-version = 0.4.7
+version = 0.4.8
 description = ACRO: Tools for the Automatic Checking of Research Outputs
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
* updates version numbers
* updates changelog
* adds Python 3.13 to the CI tests automatically run