### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See the example notebooks for:
 ### Documentation
 
 The github-pages contains pre-built [documentation](https://ai-sdc.github.io/ACRO/).
+Additionally, see our [paper describing the SACRO framework](https://arxiv.org/abs/2212.02935) to learn about its principle-based SDC methodology and usage.
 
 ### Training Materials
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -6,6 +6,8 @@ What is ACRO?
 
 A collection of tools for the automatic checking of research outputs.
 
+See our `paper describing the SACRO framework <https://arxiv.org/abs/2212.02935>`__ to learn about its principle-based SDC methodology and usage.
+
 Examples
 --------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ keywords =
     statistical-software
 project_urls =
     Changelog = https://github.com/AI-SDC/ACRO/CHANGELOG.md
-    Documentation = https://github.com/AI-SDC/ACRO/wiki
+    Documentation = https://ai-sdc.github.io/ACRO/
     Bug Tracker = https://github.com/AI-SDC/ACRO/issues
     Discussions = https://github.com/AI-SDC/ACRO/discussions
 


### PR DESCRIPTION
Following up on https://github.com/AI-SDC/ACRO/issues/254#issuecomment-2688704265 this PR adds a link to the SACRO paper to the README and docs.

It also fixes the docs URL in `setup.cfg`; the previous URL didn’t exist and just forwarded back to the main page of this repo.