### PR TITLE
chore: prepare v0.4.10

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,7 +1,11 @@
 ---
 name: PyPI Publish
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  release:
+    types:
+    - published
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.4.10 (Nov 03, 2025)
+
+Changes:
+*   fix: various fixes and improvements for stata ([#278](https://github.com/AI-SDC/ACRO/pull/278))
+*   chore: drop Python 3.9 and support Python 3.14 ([#280](https://github.com/AI-SDC/ACRO/pull/280))
+
 ## Version 0.4.9 (Jul 02, 2025)
 
 Changes:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 title: ACRO
-version: 0.4.9
-doi: 10.5281/zenodo.15793559
-date-released: 2025-07-02
+version: 0.4.10
+doi:
+date-released: 2025-11-03
 license: MIT
 repository-code: https://github.com/AI-SDC/ACRO
 languages:

--- a/acro/version.py
+++ b/acro/version.py
@@ -1,3 +1,3 @@
 """ACRO version number."""
 
-__version__ = "0.4.9"
+__version__ = "0.4.10"


### PR DESCRIPTION
* Increments version number.
* Updates CHANGELOG.
* Enables automatic PyPI deployment on release.