### PR TITLE
chore: increase max pandas to <=2.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "openpyxl",
-    "pandas>=1.5.0,<2.3",
+    "pandas<=2.33",
     "PyYAML",
     "statsmodels",
 ]


### PR DESCRIPTION
Despite CI runners here indicating that acro installs for Python 3.14, testing for the R package has indicated that Windows fails when trying to build pandas because there are no wheels available; raising the pandas version here to 2.3.3 should fix this.