### PR TITLE
fix: docs config usage; improve test network handling

### DIFF
--- a/docs/source/examples/configuration.rst
+++ b/docs/source/examples/configuration.rst
@@ -7,35 +7,62 @@ Guide to configuring ACRO for your specific needs.
 Basic Configuration
 ===================
 
+ACRO expects configuration parameters to be supplied via a YAML file.
+You can specify the name of your custom YAML configuration file when
+initializing the ACRO session.
+
+For example, if you have a file named `my_config.yaml` with the following content:
+
+.. code-block:: yaml
+
+   # my_config.yaml
+   safe_threshold: 10
+   safe_dof_threshold: 10
+   safe_nk_n: 2
+   safe_nk_k: 0.9
+   # ... other parameters ...
+
+You would then initialize your ACRO session like this:
+
 .. code-block:: python
 
    import acro
 
-   # Custom configuration
-   config = {
-       'safe_threshold': 10,
-       'safe_dof_threshold': 10,
-       'safe_nk_n': 2,
-       'safe_nk_k': 0.9
-   }
+   # Initialize with a custom configuration file
+   session = acro.ACRO(suppress=True, config='my_config.yaml')
 
-   session = acro.ACRO(suppress=True, config=config)
+.. note::
+   The `config` parameter in `acro.ACRO()` expects the *name of a YAML file* (e.g., 'my_config.yaml'), not a Python dictionary directly. If you wish to use a custom configuration, please save your parameters in a YAML file and provide its name.
 
 Environment-Specific Settings
 =============================
 
-Configuration examples for different research environments.
+You can create different YAML files for various research environments.
+
+For example, to define a 'high_security_config.yaml':
+
+.. code-block:: yaml
+
+   # high_security_config.yaml
+   safe_threshold: 20
+   safe_p_threshold: 0.01
+
+And a 'standard_config.yaml':
+
+.. code-block:: yaml
+
+   # standard_config.yaml
+   safe_threshold: 10
+   safe_p_threshold: 0.1
+
+Then, initialize your sessions accordingly:
 
 .. code-block:: python
 
-   # High-security environment
-   high_security_config = {
-       'safe_threshold': 20,
-       'safe_p_threshold': 0.01
-   }
+   import acro
 
-   # Standard research environment
-   standard_config = {
-       'safe_threshold': 10,
-       'safe_p_threshold': 0.1
-   }
+   # For a high-security environment
+   high_security_session = acro.ACRO(suppress=True, config='high_security_config.yaml')
+
+   # For a standard research environment
+   standard_session = acro.ACRO(suppress=True, config='standard_config.yaml')

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -38,6 +38,10 @@ You can specify the configuration file and whether to suppress unsafe outputs at
        suppress=True                 # Suppress unsafe outputs
    )
 
+.. note::
+   The `config` parameter in `acro.ACRO()` expects the *name of a YAML file* (e.g., 'my_config.yaml'), not a Python dictionary directly. If you wish to use a custom configuration, please save your parameters in a YAML file and provide its name.
+
+
 Safety Parameters
 =================
 


### PR DESCRIPTION
Files changed:
- test/test_initial.py
- docs/source/examples/configuration.rst
- docs/source/user_guide/configuration.rst

Changes:
- Add try-except block to handle SSL certificate verification failures
- Implement fallback to mock data when network is unavailable
- Updated configuration for Acro
- Improve test without compromising functionality validation