### PR TITLE
chore: remove unused pylint inline pragmas

### DIFF
--- a/acro/acro_regression.py
+++ b/acro/acro_regression.py
@@ -85,7 +85,7 @@ class Regression:
         )
         return results
 
-    def olsr(  # pylint: disable=keyword-arg-before-vararg
+    def olsr(
         self,
         formula: str,
         data: Any,
@@ -138,7 +138,7 @@ class Regression:
             data=data,
             subset=subset,
             drop_cols=drop_cols,
-            *args,  # noqa: B026
+            *args,
             **kwargs,
         )
         results = model.fit()
@@ -205,7 +205,7 @@ class Regression:
         )
         return results
 
-    def logitr(  # pylint: disable=keyword-arg-before-vararg
+    def logitr(
         self,
         formula: str,
         data: Any,
@@ -258,7 +258,7 @@ class Regression:
             data=data,
             subset=subset,
             drop_cols=drop_cols,
-            *args,  # noqa: B026
+            *args,
             **kwargs,
         )
         results = model.fit()
@@ -325,7 +325,7 @@ class Regression:
         )
         return results
 
-    def probitr(  # pylint: disable=keyword-arg-before-vararg
+    def probitr(
         self,
         formula: str,
         data: Any,
@@ -378,7 +378,7 @@ class Regression:
             data=data,
             subset=subset,
             drop_cols=drop_cols,
-            *args,  # noqa: B026
+            *args,
             **kwargs,
         )
         results = model.fit()

--- a/acro/acro_stata_parser.py
+++ b/acro/acro_stata_parser.py
@@ -256,7 +256,7 @@ def get_rows_cols_v17on(varlist: list[Any]) -> dict[str, Any]:
     return rows_cols
 
 
-def parse_and_run(  # pylint: disable=too-many-arguments
+def parse_and_run(
     mydata: pd.DataFrame,
     command: str,
     varlist_as_str: str,
@@ -398,9 +398,7 @@ def run_output_command(command: str, varlist: list[str]) -> str:
         return "syntax error: please pass the name of the output to be changed"
 
     # safety- rest of commands need an existing output to work on
-    if (  # pylint:disable=consider-iterating-dictionary
-        the_output not in stata_config.stata_acro.results.results.keys()
-    ):
+    if the_output not in stata_config.stata_acro.results.results:
         return f"no output with name  {the_output} in current acro session.\n"
 
     if command == "remove_output":

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -1,6 +1,5 @@
 """ACRO: Tables functions."""
 
-# pylint: disable=too-many-lines
 from __future__ import annotations
 
 import logging
@@ -73,7 +72,7 @@ class Tables:
         self.suppress: bool = suppress
         self.results: Records = Records()
 
-    def crosstab(  # pylint: disable=too-many-arguments,too-many-locals
+    def crosstab(
         self,
         index: Any,
         columns: Any,
@@ -235,7 +234,7 @@ class Tables:
             )
         return table
 
-    def pivot_table(  # pylint: disable=too-many-arguments,too-many-locals
+    def pivot_table(
         self,
         data: DataFrame,
         values: Any = None,
@@ -443,7 +442,7 @@ class Tables:
             )
         return table
 
-    def surv_func(  # pylint: disable=too-many-arguments,too-many-locals
+    def surv_func(
         self,
         time: Any,
         status: Any,
@@ -542,7 +541,7 @@ class Tables:
             return (plot, output_filename)
         return None
 
-    def survival_table(  # pylint: disable=too-many-arguments
+    def survival_table(
         self,
         survival_table: DataFrame,
         safe_table: DataFrame,
@@ -567,7 +566,7 @@ class Tables:
         )
         return survival_table
 
-    def survival_plot(  # pylint: disable=too-many-arguments
+    def survival_plot(
         self,
         survival_table: DataFrame,
         survival_func: Any,
@@ -618,7 +617,7 @@ class Tables:
         )
         return (plot, unique_filename)
 
-    def hist(  # pylint: disable=too-many-arguments,too-many-locals
+    def hist(
         self,
         data: DataFrame,
         column: str,
@@ -915,7 +914,7 @@ class Tables:
         return unique_filename
 
 
-def create_crosstab_masks(  # pylint: disable=too-many-arguments,too-many-locals
+def create_crosstab_masks(
     index: Any,
     columns: Any,
     values: Any,
@@ -1772,7 +1771,7 @@ def get_index_columns(
     return index_new, columns_new
 
 
-def crosstab_with_totals(  # pylint: disable=too-many-arguments,too-many-locals
+def crosstab_with_totals(
     masks: dict[str, DataFrame],
     aggfunc: Any,
     index: Any,
@@ -1908,7 +1907,7 @@ def crosstab_with_totals(  # pylint: disable=too-many-arguments,too-many-locals
     return table
 
 
-def manual_crossstab_with_totals(  # pylint: disable=too-many-arguments
+def manual_crossstab_with_totals(
     table: DataFrame,
     aggfunc: str | list[str] | None,
     index: Any,

--- a/acro/record.py
+++ b/acro/record.py
@@ -58,7 +58,7 @@ def load_output(path: str, output: list[str]) -> list[str] | list[DataFrame]:
     return loaded
 
 
-class Record:  # pylint: disable=too-many-instance-attributes
+class Record:
     """Stores data related to a single output record.
 
     Attributes
@@ -89,7 +89,7 @@ class Record:  # pylint: disable=too-many-instance-attributes
         Time the record was created in ISO format.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         uid: str,
         status: str,
@@ -214,7 +214,7 @@ class Records:
         self.results: dict[str, Record] = {}
         self.output_id: int = 0
 
-    def add(  # pylint: disable=too-many-arguments
+    def add(
         self,
         status: str,
         output_type: str,
@@ -510,9 +510,7 @@ class Records:
             logger.debug("Directory %s created successfully", path)
         except FileExistsError:  # pragma: no cover
             logger.debug("Directory %s already exists", path)
-        with pd.ExcelWriter(  # pylint: disable=abstract-class-instantiated
-            filename, engine="openpyxl"
-        ) as writer:
+        with pd.ExcelWriter(filename, engine="openpyxl") as writer:
             # description sheet
             sheet: list[str] = []
             summary: list[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,8 @@ lint.ignore = [
 [tool.ruff.lint.per-file-ignores]
 "test/*.py" = ["ANN"]
 "acro_stata_parser.py" = ["C901"]
+"acro/acro_regression.py" = ["B026"]
+
 
 [tool.ruff.lint.pep8-naming]
 extend-ignore-names = ["X", "X_train", "X_predict"]

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -14,8 +14,6 @@ from acro import ACRO, acro_tables, add_constant, add_to_acro, record, utils
 from acro.acro_tables import _rounded_survival_table, crosstab_with_totals
 from acro.record import Records, load_records
 
-# pylint: disable=redefined-outer-name,too-many-lines
-
 PATH: str = "RES_PYTEST"
 
 

--- a/test/test_stata17_interface.py
+++ b/test/test_stata17_interface.py
@@ -1,11 +1,5 @@
 """Unit tests for the stata 17 interface."""
 
-# The pylint skip file is to skip the error of R0801: Similar lines in 2 files. As the
-# file  this file and the file test_stata_interface.py have a lot of similarities.
-# That is because we are testing the same functions for different versions of Stata.
-
-# pylint: skip-file
-
 import copy
 import os
 import shutil
@@ -13,13 +7,10 @@ import shutil
 import pandas as pd
 import pytest
 
-import acro.stata_config as stata_config  # pylint: disable=consider-using-from-import
+import acro.stata_config as stata_config
 from acro import ACRO
 from acro.acro_stata_parser import find_brace_word, parse_and_run, parse_table_details
 from acro.acro_tables import AGGFUNC
-
-# pylint: disable=redefined-outer-name
-
 
 # @pytest.fixture
 # def acro() -> ACRO:
@@ -46,7 +37,7 @@ def clean_up(name):
 
 def dummy_acrohandler(
     data, command, varlist, exclusion, exp, weights, options, stata_version
-):  # pylint:disable=too-many-arguments
+):
     """
     Provide an alternative interface that mimics the code in acro.ado.
 
@@ -635,7 +626,6 @@ def test_table_aggcfn(data):
     assert ret.split() == correct.split(), f"got:\n{ret}\naa\nexpected\n{correct}\nbb\n"
 
     # lists for index or columns
-    # pylint: disable=duplicate-code
     correct = (
         "Total\n"
         "------------------------------------------------------------|\n"
@@ -818,7 +808,6 @@ def test_unsupported_formatting_options(data):
         "Alive in 2015  |72  |354  |144  |48 |\n"
         "------------------------------------|\n"
     )
-    # pylint:disable=duplicate-code
     for bad_option in [
         "cellwidth",
         "csepwidth",

--- a/test/test_stata_interface.py
+++ b/test/test_stata_interface.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import acro.stata_config as stata_config  # pylint: disable=consider-using-from-import
+import acro.stata_config as stata_config
 from acro import ACRO
 from acro.acro_stata_parser import (
     apply_stata_expstmt,
@@ -18,9 +18,6 @@ from acro.acro_stata_parser import (
     parse_table_details,
 )
 from acro.acro_tables import AGGFUNC
-
-# pylint: disable=redefined-outer-name
-
 
 # @pytest.fixture
 # def acro() -> ACRO:
@@ -47,7 +44,7 @@ def clean_up(name):
 
 def dummy_acrohandler(
     data, command, varlist, exclusion, exp, weights, options, stata_version
-):  # pylint:disable=too-many-arguments
+):
     """
     Provide an alternative interface that mimics the code in acro.ado.
 
@@ -716,7 +713,6 @@ def test_table_aggcfn(data):
     assert ret.split() == correct.split(), f"got:\n{ret}\naa\nexpected\n{correct}\nbb\n"
 
     # lists for index or columns
-    # pylint: disable=duplicate-code
     correct = (
         "Total\n"
         "------------------------------------------------------------|\n"
@@ -888,7 +884,6 @@ def test_unsupported_formatting_options(data):
         "Alive in 2015  |72  |354  |144  |48 |\n"
         "------------------------------------|\n"
     )
-    # pylint:disable=duplicate-code
     for bad_option in [
         "cellwidth",
         "csepwidth",


### PR DESCRIPTION
Hi @rpreen 

Removed all # pylint: disable=... and # pylint: skip-file inline pragmas from the codebase. 
No logic, function signatures, or imports were changed. All pre-commit hooks pass.

Ref #348