### PR TITLE
chore: enable 11 additional ruff lint rule sets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,32 +95,32 @@ lint.select = [
   "ANN", # flake8-annotations
   "ARG", # flake8-unused-arguments
   "B",   # flake8-bugbear
-#  "C4",  # flake8-comprehensions
+  "C4",  # flake8-comprehensions
   "C90", # mccabe
   "D",   # pydocstyle
-#  "DTZ", # flake8-datetimez
-#  "E",   # pycodestyle
-#  "EM",  # flake8-errmsg
-#  "ERA", # eradicate
+  "DTZ", # flake8-datetimez
+  "E",   # pycodestyle
+  "EM",  # flake8-errmsg
+#  "ERA", # eradicate — 42 violations across tests/notebooks/source; cleanup follow-up
   "F",   # Pyflakes
   "I",   # isort
   "ICN",  # flake8-import-conventions
   "N",   # pep8-naming
-#  "PD",  # pandas-vet
+  "PD",  # pandas-vet
   "PGH", # pygrep-hooks
   "PIE",  # flake8-pie
-#  "PL",  # Pylint
+#  "PL",  # Pylint (use PLC/PLE/PLR/PLW individually)
   "PLC", # Pylint
   "PLE", # Pylint
-#  "PLR", # Pylint
-#  "PLW", # Pylint
+  "PLR", # Pylint
+  "PLW", # Pylint
   "PT",  # flake8-pytest-style
   "Q",   # flake8-quotes
-#  "RET", # flake8-return
+  "RET", # flake8-return
   "RUF100",  # Ruff-specific
-#  "S",   # flake8-bandit
-#  "SIM", # flake8-simplify
-#  "T20", # flake8-print
+  "S",   # flake8-bandit
+  "SIM", # flake8-simplify
+  "T20", # flake8-print
   "TID", # flake8-tidy-imports
   "UP",  # pyupgrade
   "W",   # pycodestyle
@@ -133,16 +133,31 @@ exclude = [
 ]
 
 lint.ignore = [
-  "ANN401",
-#  "ANN101", # missing-type-self
-#  "S301",   # unsafe pickle
+  "ANN401",  # dynamically typed Any
+  "E501",    # line too long — enforced by ruff formatter, redundant in linter
+  "PD009",   # .iat vs .iloc — .iat is intentional for scalar access
+  "PD010",   # .unstack vs .pivot_table — style preference
+  "PD013",   # .stack vs .melt — style preference
+  "PLR2004", # magic value comparison — ubiquitous in tests and parser constants
+  "RET504",  # unnecessary assignment before return — aids readability/debugging
+  "S101",    # assert usage — standard in tests and production invariant checks
+  "S301",    # unsafe pickle — used intentionally in this project
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"test/*.py" = ["ANN"]
-"acro_stata_parser.py" = ["C901"]
+"test/*.py" = ["ANN", "PD", "PLR0402", "PLR0913", "PLR5501", "SIM300", "T20"]
+"notebooks/**" = ["E402", "PD", "T20"]
+"acro/acro_stata_parser.py" = ["C901", "C417", "PLR5501", "T20"]
+"acro/acro_tables.py" = ["EM", "PD002", "PD011", "PD101", "PLR0913", "PLR1714", "PLW2901", "SIM102", "SIM108"]
 "acro/acro_regression.py" = ["B026"]
+"acro/record.py" = ["DTZ005", "EM", "PLW2901", "T20"]
+"acro/acro.py" = ["SIM113"]
+"acro/utils.py" = ["PD002"]
 
+
+[tool.ruff.lint.pylint]
+max-args = 12
+max-returns = 10
 
 [tool.ruff.lint.pep8-naming]
 extend-ignore-names = ["X", "X_train", "X_predict"]


### PR DESCRIPTION
Enable 11 previously-disabled ruff rule sets via config-only changes to `pyproject.toml`. No Python source files were modified.

### Enabled rule sets
C4, DTZ, E, EM, PD, PLR, PLW, RET, S, SIM, T20

### Left disabled
ERA - 42 violations across tests, notebooks, and source files. Better suited as a dedicated cleanup PR.

### Strategy
- **Threshold tuning:** `max-args = 12`, `max-returns = 10`
- **Global ignores (9 rules):** E501, PD009, PD010, PD013, PLR2004, RET504, S101, S301
- **Per-file-ignores:** targeted suppression for 8 file patterns
- **Cleanup:** removed old commented-out ANN101 and S301 lines

### Future refactoring candidates
Per-file-ignores that could be removed after dedicated cleanup PRs:
- `acro/acro_tables.py` - PLR0913, PLR1714, SIM102, SIM108, PLW2901, EM, PD002, PD011, PD101
- `acro/acro_stata_parser.py` - C417, PLR5501, T20
- `acro/record.py` - DTZ005, EM, PLW2901, T20
- `acro/acro.py` - SIM113
- `acro/utils.py` - PD002
@rpreen 

Closes #348