### PR TITLE
feat: create and enforce blocked file extension list for custom outputs

### DIFF
--- a/acro/acro.py
+++ b/acro/acro.py
@@ -80,10 +80,6 @@ class ACRO(Tables, Regression):
         acro_tables.ZEROS_ARE_DISCLOSIVE = self.config["zeros_are_disclosive"]
         # set globals for survival analysis
         acro_tables.SURVIVAL_THRESHOLD = self.config["survival_safe_threshold"]
-        # set globals for blocked file extensions
-        acro_tables.BLOCKED_EXTENSIONS = [
-            ext.lower() for ext in self.config.get("blocked_extensions", [])
-        ]
 
     def finalise(
         self, path: str = "outputs", ext: str = "json", interactive: bool = False

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -60,12 +60,14 @@ class ACRO(Tables, Regression):
         Tables.__init__(self, suppress)
         Regression.__init__(self, config)
         self.config: dict[str, Any] = {}
-        self.results: Records = Records()
         self.suppress: bool = suppress
         path: pathlib.Path = pathlib.Path(__file__).with_name(config + ".yaml")
         logger.debug("path: %s", path)
         with open(path, encoding="utf-8") as handle:
             self.config = yaml.load(handle, Loader=yaml.loader.SafeLoader)
+        self.results: Records = Records(
+            blocked_extensions=self.config.get("blocked_extensions", [])
+        )
         logger.info("version: %s", __version__)
         logger.info("config: %s", self.config)
         logger.info("automatic suppression: %s", self.suppress)
@@ -78,6 +80,10 @@ class ACRO(Tables, Regression):
         acro_tables.ZEROS_ARE_DISCLOSIVE = self.config["zeros_are_disclosive"]
         # set globals for survival analysis
         acro_tables.SURVIVAL_THRESHOLD = self.config["survival_safe_threshold"]
+        # set globals for blocked file extensions
+        acro_tables.BLOCKED_EXTENSIONS = [
+            ext.lower() for ext in self.config.get("blocked_extensions", [])
+        ]
 
     def finalise(
         self, path: str = "outputs", ext: str = "json", interactive: bool = False
@@ -138,7 +144,7 @@ class ACRO(Tables, Regression):
         """
         return self.results.print()
 
-    def custom_output(self, filename: str, comment: str = "") -> None:
+    def custom_output(self, filename: str, comment: str = "") -> bool:
         """Add an unsupported output to the results dictionary.
 
         Parameters
@@ -147,8 +153,13 @@ class ACRO(Tables, Regression):
             The name of the file that will be added to the list of the outputs.
         comment : str
             An optional comment.
+
+        Returns
+        -------
+        bool
+            False if the file extension is blocked, True otherwise.
         """
-        self.results.add_custom(filename, comment)
+        return self.results.add_custom(filename, comment)
 
     def rename_output(self, old: str, new: str) -> None:
         """Rename an output.

--- a/acro/acro_stata_parser.py
+++ b/acro/acro_stata_parser.py
@@ -376,12 +376,10 @@ def add_custom_output(varlist: list[str]) -> str:
     except IndexError:
         return "syntax error: please pass the name of the output to be added"
 
-    # .gph extension contain data
-    _, file_extension = os.path.splitext(the_output)
-    if file_extension == ".gph":
-        return "Warning: .gph files may not be exported as they contain data."
     comment_str = " ".join(varlist)
-    stata_config.stata_acro.custom_output(the_output, comment_str)
+    if not stata_config.stata_acro.custom_output(the_output, comment_str):
+        _, ext = os.path.splitext(the_output)
+        return f"Warning: {ext} files are not allowed and cannot be exported."
     outcome = f"file {the_output} with comment {comment_str} added to session."
     return outcome
 

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -580,6 +580,14 @@ class Tables:
         summary: str,
     ) -> tuple[Any, str] | None:
         """Create the survival plot according to the status of suppressing."""
+        _, extension = os.path.splitext(filename)
+        if extension.lower() in BLOCKED_EXTENSIONS:
+            logger.warning(
+                "Blocked file extension %s. Files with extension %s are not allowed.",
+                extension,
+                extension,
+            )
+            return None
         if self.suppress:
             survival_table = _rounded_survival_table(survival_table)
             plot = survival_table.plot(y="rounded_survival_fun", xlim=0, ylim=0)
@@ -597,13 +605,6 @@ class Tables:
         if not extension:  # pragma: no cover
             logger.info("Please provide a valid file extension")
             return None  # pragma: no cover
-        if extension.lower() in BLOCKED_EXTENSIONS:
-            logger.warning(
-                "Blocked file extension %s. Files with extension %s are not allowed.",
-                extension,
-                extension,
-            )
-            return None
         increment_number = 0
         while os.path.exists(
             f"acro_artifacts/{filename}_{increment_number}{extension}"
@@ -712,6 +713,14 @@ class Tables:
             The name of the file where the histogram is saved.
         """
         logger.debug("hist()")
+        _, extension = os.path.splitext(filename)
+        if extension.lower() in BLOCKED_EXTENSIONS:
+            logger.warning(
+                "Blocked file extension %s. Files with extension %s are not allowed.",
+                extension,
+                extension,
+            )
+            return None
         command: str = utils.get_command("hist()", stack())
 
         if isinstance(data, list):  # pragma: no cover
@@ -798,13 +807,6 @@ class Tables:
         if not extension:  # pragma: no cover
             logger.info("Please provide a valid file extension")
             return None
-        if extension.lower() in BLOCKED_EXTENSIONS:
-            logger.warning(
-                "Blocked file extension %s. Files with extension %s are not allowed.",
-                extension,
-                extension,
-            )
-            return None
         increment_number = 0
         while os.path.exists(
             f"acro_artifacts/{filename}_{increment_number}{extension}"
@@ -864,6 +866,14 @@ class Tables:
             The path to the saved pie chart file.
         """
         logger.debug("pie()")
+        _, extension = os.path.splitext(filename)
+        if extension.lower() in BLOCKED_EXTENSIONS:
+            logger.warning(
+                "Blocked file extension %s. Files with extension %s are not allowed.",
+                extension,
+                extension,
+            )
+            return None
         command: str = utils.get_command("pie()", stack())
 
         # COMPUTE PRE-CATEGORY COUNTS
@@ -904,13 +914,6 @@ class Tables:
         filename, extension = os.path.splitext(filename)
         if not extension:  # pragma: no cover
             logger.info("Please provide a valid file extension")
-            return None
-        if extension.lower() in BLOCKED_EXTENSIONS:
-            logger.warning(
-                "Blocked file extension %s. Files with extension %s are not allowed.",
-                extension,
-                extension,
-            )
             return None
         increment_number = 0
 

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -58,6 +58,9 @@ ZEROS_ARE_DISCLOSIVE: bool = True
 # survival analysis parameters
 SURVIVAL_THRESHOLD: int = 10
 
+# blocked file extensions for outputs
+BLOCKED_EXTENSIONS: list[str] = []
+
 
 class Tables:
     """Creates tabular data.
@@ -594,6 +597,13 @@ class Tables:
         if not extension:  # pragma: no cover
             logger.info("Please provide a valid file extension")
             return None  # pragma: no cover
+        if extension.lower() in BLOCKED_EXTENSIONS:
+            logger.warning(
+                "Blocked file extension %s. Files with extension %s are not allowed.",
+                extension,
+                extension,
+            )
+            return None
         increment_number = 0
         while os.path.exists(
             f"acro_artifacts/{filename}_{increment_number}{extension}"
@@ -788,6 +798,13 @@ class Tables:
         if not extension:  # pragma: no cover
             logger.info("Please provide a valid file extension")
             return None
+        if extension.lower() in BLOCKED_EXTENSIONS:
+            logger.warning(
+                "Blocked file extension %s. Files with extension %s are not allowed.",
+                extension,
+                extension,
+            )
+            return None
         increment_number = 0
         while os.path.exists(
             f"acro_artifacts/{filename}_{increment_number}{extension}"
@@ -887,6 +904,13 @@ class Tables:
         filename, extension = os.path.splitext(filename)
         if not extension:  # pragma: no cover
             logger.info("Please provide a valid file extension")
+            return None
+        if extension.lower() in BLOCKED_EXTENSIONS:
+            logger.warning(
+                "Blocked file extension %s. Files with extension %s are not allowed.",
+                extension,
+                extension,
+            )
             return None
         increment_number = 0
 

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -58,9 +58,6 @@ ZEROS_ARE_DISCLOSIVE: bool = True
 # survival analysis parameters
 SURVIVAL_THRESHOLD: int = 10
 
-# blocked file extensions for outputs
-BLOCKED_EXTENSIONS: list[str] = []
-
 
 class Tables:
     """Creates tabular data.
@@ -580,13 +577,7 @@ class Tables:
         summary: str,
     ) -> tuple[Any, str] | None:
         """Create the survival plot according to the status of suppressing."""
-        _, extension = os.path.splitext(filename)
-        if extension.lower() in BLOCKED_EXTENSIONS:
-            logger.warning(
-                "Blocked file extension %s. Files with extension %s are not allowed.",
-                extension,
-                extension,
-            )
+        if utils.is_blocked_extension(filename, self.results.blocked_extensions):
             return None
         if self.suppress:
             survival_table = _rounded_survival_table(survival_table)
@@ -713,13 +704,7 @@ class Tables:
             The name of the file where the histogram is saved.
         """
         logger.debug("hist()")
-        _, extension = os.path.splitext(filename)
-        if extension.lower() in BLOCKED_EXTENSIONS:
-            logger.warning(
-                "Blocked file extension %s. Files with extension %s are not allowed.",
-                extension,
-                extension,
-            )
+        if utils.is_blocked_extension(filename, self.results.blocked_extensions):
             return None
         command: str = utils.get_command("hist()", stack())
 
@@ -866,13 +851,7 @@ class Tables:
             The path to the saved pie chart file.
         """
         logger.debug("pie()")
-        _, extension = os.path.splitext(filename)
-        if extension.lower() in BLOCKED_EXTENSIONS:
-            logger.warning(
-                "Blocked file extension %s. Files with extension %s are not allowed.",
-                extension,
-                extension,
-            )
+        if utils.is_blocked_extension(filename, self.results.blocked_extensions):
             return None
         command: str = utils.get_command("pie()", stack())
 

--- a/acro/default.yaml
+++ b/acro/default.yaml
@@ -29,4 +29,13 @@ survival_safe_threshold: 10
 
 # consider zeros to be disclosive
 zeros_are_disclosive: True
+
+################################################################################
+# Blocked file extensions                                                      #
+################################################################################
+# File extensions that are not allowed in custom outputs or plots.
+# Extensions are case-insensitive and must include the leading dot.
+blocked_extensions:
+  - .svg
+  - .gph
 ...

--- a/acro/record.py
+++ b/acro/record.py
@@ -209,10 +209,19 @@ class Record:
 class Records:
     """Stores data related to a collection of output records."""
 
-    def __init__(self) -> None:
-        """Construct a new object for storing multiple records."""
+    def __init__(self, blocked_extensions: list[str] | None = None) -> None:
+        """Construct a new object for storing multiple records.
+
+        Parameters
+        ----------
+        blocked_extensions : list[str] | None, default None
+            File extensions that are not allowed in custom outputs.
+        """
         self.results: dict[str, Record] = {}
         self.output_id: int = 0
+        self.blocked_extensions: list[str] = [
+            ext.lower() for ext in (blocked_extensions or [])
+        ]
 
     def add(
         self,
@@ -322,7 +331,7 @@ class Records:
         key = list(self.results.keys())[index]
         return self.results[key]
 
-    def add_custom(self, filename: str, comment: str | None = None) -> None:
+    def add_custom(self, filename: str, comment: str | None = None) -> bool:
         """Add an unsupported output to the results dictionary.
 
         Parameters
@@ -331,7 +340,20 @@ class Records:
             The name of the file that will be added to the list of the outputs.
         comment : str | None, default None
             An optional comment.
+
+        Returns
+        -------
+        bool
+            False if the file extension is blocked, True otherwise.
         """
+        _, ext = os.path.splitext(filename)
+        if ext.lower() in self.blocked_extensions:
+            logger.warning(
+                "Blocked file extension %s. Files with extension %s are not allowed.",
+                filename,
+                ext,
+            )
+            return False
         if os.path.exists(filename):
             output = Record(
                 uid=f"output_{self.output_id}",
@@ -352,6 +374,7 @@ class Records:
             logger.info(
                 "WARNING: Unable to add %s because the file does not exist", filename
             )  # pragma: no cover
+        return True
 
     def rename(self, old: str, new: str) -> None:
         """Rename an output.

--- a/acro/record.py
+++ b/acro/record.py
@@ -14,6 +14,7 @@ from typing import Any
 import pandas as pd
 from pandas import DataFrame
 
+from .utils import is_blocked_extension
 from .version import __version__
 
 logger = logging.getLogger("acro:records")
@@ -346,13 +347,7 @@ class Records:
         bool
             False if the file extension is blocked, True otherwise.
         """
-        _, ext = os.path.splitext(filename)
-        if ext.lower() in self.blocked_extensions:
-            logger.warning(
-                "Blocked file extension %s. Files with extension %s are not allowed.",
-                filename,
-                ext,
-            )
+        if is_blocked_extension(filename, self.blocked_extensions):
             return False
         if os.path.exists(filename):
             output = Record(

--- a/acro/record.py
+++ b/acro/record.py
@@ -211,13 +211,7 @@ class Records:
     """Stores data related to a collection of output records."""
 
     def __init__(self, blocked_extensions: list[str] | None = None) -> None:
-        """Construct a new object for storing multiple records.
-
-        Parameters
-        ----------
-        blocked_extensions : list[str] | None, default None
-            File extensions that are not allowed in custom outputs.
-        """
+        """Construct a new object for storing multiple records."""
         self.results: dict[str, Record] = {}
         self.output_id: int = 0
         self.blocked_extensions: list[str] = [

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -3,11 +3,25 @@
 from __future__ import annotations
 
 import logging
+import os
 from inspect import FrameInfo, getframeinfo
 
 import pandas as pd
 
 logger = logging.getLogger("acro")
+
+
+def is_blocked_extension(filename: str, blocked_extensions: list[str]) -> bool:
+    """Return True and log a warning if the file's extension is blocked."""
+    _, ext = os.path.splitext(filename)
+    if ext.lower() in blocked_extensions:
+        logger.warning(
+            "Blocked file extension %s. Files with extension %s are not allowed.",
+            filename,
+            ext,
+        )
+        return True
+    return False
 
 
 def get_command(default: str, stack_list: list[FrameInfo]) -> str:

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -505,6 +505,32 @@ def test_custom_output(acro):
     shutil.rmtree(PATH)
 
 
+def test_blocked_extension(acro, tmp_path):
+    """Test that blocked file extensions are rejected in custom output."""
+    # create temporary files with blocked extensions
+    svg_file = tmp_path / "test.svg"
+    svg_file.write_text("<svg></svg>")
+    gph_file = tmp_path / "test.gph"
+    gph_file.write_text("data")
+
+    # blocked extensions should be rejected
+    acro.custom_output(str(svg_file))
+    acro.custom_output(str(gph_file))
+    assert len(acro.results.results) == 0
+
+    # allowed extensions should be accepted
+    txt_file = tmp_path / "test.txt"
+    txt_file.write_text("hello")
+    acro.custom_output(str(txt_file))
+    assert len(acro.results.results) == 1
+
+    # case-insensitive check
+    svg_upper = tmp_path / "test.SVG"
+    svg_upper.write_text("<svg></svg>")
+    acro.custom_output(str(svg_upper))
+    assert len(acro.results.results) == 1
+
+
 def test_missing(data, acro, monkeypatch):
     """Pivot table and Crosstab with negative values."""
     acro_tables.CHECK_MISSING_VALUES = True

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -531,6 +531,35 @@ def test_blocked_extension(acro, tmp_path):
     assert len(acro.results.results) == 1
 
 
+def test_blocked_extension_hist(data, acro):
+    """Test that blocked file extensions are rejected for histograms."""
+    result = acro.hist(data, "inc_grants", bins=1, filename="hist.svg")
+    assert result is None
+    assert len(acro.results.results) == 0
+
+
+def test_blocked_extension_pie(data, acro):
+    """Test that blocked file extensions are rejected for pie charts."""
+    result = acro.pie(data, "grant_type", filename="pie.svg")
+    assert result is None
+    assert len(acro.results.results) == 0
+
+
+def test_blocked_extension_survival(acro):
+    """Test that blocked file extensions are rejected for survival plots."""
+    result = acro.survival_plot(
+        survival_table=pd.DataFrame(),
+        survival_func=None,
+        filename="surv.svg",
+        status="pass",
+        sdc={},
+        command="test",
+        summary="test",
+    )
+    assert result is None
+    assert len(acro.results.results) == 0
+
+
 def test_missing(data, acro, monkeypatch):
     """Pivot table and Crosstab with negative values."""
     acro_tables.CHECK_MISSING_VALUES = True

--- a/test/test_stata17_interface.py
+++ b/test/test_stata17_interface.py
@@ -472,7 +472,7 @@ def test_stata_custom_output_invalid():
         options="nototals",
         stata_version="17",
     )
-    correct = "Warning: .gph files may not be exported as they contain data."
+    correct = "Warning: .gph files are not allowed and cannot be exported."
     assert ret == correct, f" we got : {ret}\nexpected:{correct}"
     newres = stata_config.stata_acro.results.__dict__
     assert newres == previous, (

--- a/test/test_stata_interface.py
+++ b/test/test_stata_interface.py
@@ -562,7 +562,7 @@ def test_stata_custom_output_invalid():
         options="nototals",
         stata_version="17",
     )
-    correct = "Warning: .gph files may not be exported as they contain data."
+    correct = "Warning: .gph files are not allowed and cannot be exported."
     assert ret == correct, f" we got : {ret}\nexpected:{correct}"
     newres = stata_config.stata_acro.results.__dict__
     assert newres == previous, (


### PR DESCRIPTION
## Summary
- Add a configurable `blocked_extensions` list in `default.yaml` (`.svg`, `.gph`) to prevent potentially disclosive file types from being added as custom outputs or plots
- Centralize file extension validation in `Records.add_custom()` - replaces the hardcoded `.gph` check in the Stata parser
- Apply the same extension check to `hist()`, `pie()`, and `survival_plot()` outputs

Closes #124

@jim-smith 