### PR TITLE
feat: add rounding as a protection mechanism

### DIFF
--- a/acro/acro.py
+++ b/acro/acro.py
@@ -31,8 +31,14 @@ class ACRO(Tables, Regression):
         Safe parameters and their values.
     results : Records
         The current outputs including the results of checks.
+    mitigation : str
+        The disclosure-control strategy applied to outputs, one of ``"none"``,
+        ``"suppress"``, ``"round"``.
+    round_base : int
+        The base to round to when ``mitigation == "round"``.
     suppress : bool
-        Whether to automatically apply suppression
+        Backward-compatible alias. ``True`` is equivalent to
+        ``mitigation == "suppress"``.
 
     Examples
     --------
@@ -47,7 +53,13 @@ class ACRO(Tables, Regression):
     ... )
     """
 
-    def __init__(self, config: str = "default", suppress: bool = False) -> None:
+    def __init__(
+        self,
+        config: str = "default",
+        suppress: bool = False,
+        mitigation: str | None = None,
+        round_base: int | None = None,
+    ) -> None:
         """Construct a new ACRO object and reads parameters from config.
 
         Parameters
@@ -55,20 +67,23 @@ class ACRO(Tables, Regression):
         config : str
             Name of a yaml configuration file with safe parameters.
         suppress : bool, default False
-            Whether to automatically apply suppression.
+            Whether to automatically apply suppression (back-compat alias for
+            ``mitigation="suppress"``). Ignored when ``mitigation`` is set.
+        mitigation : str, optional
+            The disclosure-control strategy to apply, one of ``"none"``,
+            ``"suppress"``, ``"round"``. When ``None``, derived from
+            ``suppress``.
+        round_base : int, optional
+            The base to round to when ``mitigation="round"``. Defaults to the
+            ``safe_round_base`` value from the yaml config.
         """
-        Tables.__init__(self, suppress)
+        Tables.__init__(self, suppress=suppress, mitigation=mitigation)
         Regression.__init__(self, config)
         self.config: dict[str, Any] = {}
-        self.results: Records = Records()
-        self.suppress: bool = suppress
         path: pathlib.Path = pathlib.Path(__file__).with_name(config + ".yaml")
         logger.debug("path: %s", path)
         with open(path, encoding="utf-8") as handle:
             self.config = yaml.load(handle, Loader=yaml.loader.SafeLoader)
-        logger.info("version: %s", __version__)
-        logger.info("config: %s", self.config)
-        logger.info("automatic suppression: %s", self.suppress)
         # set globals needed for aggregation functions
         acro_tables.THRESHOLD = self.config["safe_threshold"]
         acro_tables.SAFE_PRATIO_P = self.config["safe_pratio_p"]
@@ -78,6 +93,16 @@ class ACRO(Tables, Regression):
         acro_tables.ZEROS_ARE_DISCLOSIVE = self.config["zeros_are_disclosive"]
         # set globals for survival analysis
         acro_tables.SURVIVAL_THRESHOLD = self.config["survival_safe_threshold"]
+        # set globals and instance state for the round mitigation strategy
+        acro_tables.SAFE_ROUND_BASE = self.config.get(
+            "safe_round_base", acro_tables.SAFE_ROUND_BASE
+        )
+        self.round_base = (
+            round_base if round_base is not None else acro_tables.SAFE_ROUND_BASE
+        )
+        logger.info("version: %s", __version__)
+        logger.info("config: %s", self.config)
+        logger.info("mitigation: %s (round_base=%s)", self.mitigation, self.round_base)
 
     def finalise(
         self, path: str = "outputs", ext: str = "json", interactive: bool = False
@@ -193,6 +218,23 @@ class ACRO(Tables, Regression):
     def disable_suppression(self) -> None:
         """Turn suppression off during a session."""
         self.suppress = False
+
+    def enable_rounding(self, base: int | None = None) -> None:
+        """Turn rounding on during a session.
+
+        Parameters
+        ----------
+        base : int, optional
+            The rounding base. When ``None`` the current ``round_base`` is kept.
+        """
+        if base is not None:
+            self.round_base = base
+        self.mitigation = "round"
+
+    def disable_rounding(self) -> None:
+        """Turn rounding off during a session."""
+        if self.mitigation == "round":
+            self.mitigation = "none"
 
 
 def add_to_acro(src_path: str, dest_path: str = "sdc_results") -> None:

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -220,7 +220,8 @@ class ACRO(Tables, Regression):
         self.suppress = False
 
     def enable_rounding(self, base: int | None = None) -> None:
-        """Turn rounding on during a session.
+        """
+        Turn rounding on during a session.
 
         Parameters
         ----------

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -79,6 +79,11 @@ class ACRO(Tables, Regression):
         """
         Tables.__init__(self, suppress=suppress, mitigation=mitigation)
         Regression.__init__(self, config)
+        # Tables and Regression each construct their own ``self.results`` so
+        # they can be used standalone; in the combined ACRO object we want a
+        # single shared Records instance regardless of init order, so make
+        # that explicit here.
+        self.results: Records = Records()
         self.config: dict[str, Any] = {}
         path: pathlib.Path = pathlib.Path(__file__).with_name(config + ".yaml")
         logger.debug("path: %s", path)

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -225,13 +225,13 @@ class ACRO(Tables, Regression):
         self.suppress = False
 
     def enable_rounding(self, base: int | None = None) -> None:
-        """Turn rounding on; if ``base`` is given, use it as the new ``round_base``."""
+        """Turn rounding on; overwrites any prior suppress=True (not restored on disable_rounding)."""
         if base is not None:
             self.round_base = base
         self.mitigation = "round"
 
     def disable_rounding(self) -> None:
-        """Turn rounding off during a session."""
+        """Turn rounding off; always falls back to mitigation='none' (prior suppress not restored)."""
         if self.mitigation == "round":
             self.mitigation = "none"
 

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -89,6 +89,12 @@ class ACRO(Tables, Regression):
         logger.debug("path: %s", path)
         with open(path, encoding="utf-8") as handle:
             self.config = yaml.load(handle, Loader=yaml.loader.SafeLoader)
+        # Preserve the user-requested suppress value alongside the yaml config.
+        # Tables.suppress is now a property derived from the live mitigation, so
+        # it can drift over a session (enable_rounding flips mitigation away from
+        # 'suppress'). Recording the original ask here keeps it available for
+        # callers that need to re-enforce suppression for disclosive outputs.
+        self.config["suppress"] = suppress
         # set globals needed for aggregation functions
         acro_tables.THRESHOLD = self.config["safe_threshold"]
         acro_tables.SAFE_PRATIO_P = self.config["safe_pratio_p"]

--- a/acro/acro.py
+++ b/acro/acro.py
@@ -220,14 +220,7 @@ class ACRO(Tables, Regression):
         self.suppress = False
 
     def enable_rounding(self, base: int | None = None) -> None:
-        """
-        Turn rounding on during a session.
-
-        Parameters
-        ----------
-        base : int, optional
-            The rounding base. When ``None`` the current ``round_base`` is kept.
-        """
+        """Turn rounding on; if ``base`` is given, use it as the new ``round_base``."""
         if base is not None:
             self.round_base = base
         self.mitigation = "round"

--- a/acro/acro_stata_parser.py
+++ b/acro/acro_stata_parser.py
@@ -5,6 +5,7 @@ Jim Smith 2023 @james.smith@uwe.ac.uk
 MIT licenses apply.
 """
 
+import logging
 import os
 import re
 from typing import Any
@@ -14,7 +15,9 @@ from statsmodels.iolib import summary as sm_iolib_summary
 
 from acro import ACRO, acro_regression, add_constant, stata_config
 from acro.acro_tables import AGGFUNC
-from acro.utils import prettify_table_string
+from acro.utils import ALLOWED_MITIGATIONS, prettify_table_string
+
+logger = logging.getLogger("acro")
 
 
 def apply_stata_ifstmt(raw: str, all_data: pd.DataFrame) -> pd.DataFrame:
@@ -345,11 +348,28 @@ def _parse_init_options(options: str) -> dict[str, Any]:
     found, mitigation = find_brace_word("mitigation", options)
     if found:
         assert len(mitigation) == 1, "can only supply one mitigation value"
-        args["mitigation"] = mitigation[0]
+        proposed = mitigation[0]
+        if proposed in ALLOWED_MITIGATIONS:
+            args["mitigation"] = proposed
+        else:
+            logger.info(
+                "Sorry, I don't recognise the mitigation %r. "
+                "It should be one of %s. Proceeding with no mitigation.",
+                proposed,
+                sorted(ALLOWED_MITIGATIONS),
+            )
+            args["mitigation"] = "none"
     found, round_base = find_brace_word("round_base", options)
     if found:
         assert len(round_base) == 1, "can only supply one round_base value"
-        args["round_base"] = int(round_base[0])
+        try:
+            args["round_base"] = int(round_base[0])
+        except (TypeError, ValueError):
+            logger.info(
+                "round_base value %r is not an integer; "
+                "falling back to the default round_base from the config.",
+                round_base[0],
+            )
     return args
 
 
@@ -370,7 +390,15 @@ def run_session_command(command: str, varlist: list[str], options: str) -> str:
     elif command == "enable_rounding":
         base_arg: int | None = None
         if varlist:
-            base_arg = int(varlist[0])
+            try:
+                base_arg = int(varlist[0])
+            except (TypeError, ValueError):
+                logger.info(
+                    "rounding base %r is not an integer; "
+                    "turning rounding on with the default base.",
+                    varlist[0],
+                )
+                base_arg = None
         stata_config.stata_acro.enable_rounding(base_arg)
         outcome = "rounding toggled on for subsequent commands"
     elif command == "disable_rounding":

--- a/acro/acro_stata_parser.py
+++ b/acro/acro_stata_parser.py
@@ -301,6 +301,8 @@ def parse_and_run(
         "finalise",
         "enable_suppression",
         "disable_suppression",
+        "enable_rounding",
+        "disable_rounding",
         "print_outputs",
     ]
     output_commands = [
@@ -330,20 +332,33 @@ def parse_and_run(
     return outcome
 
 
+def _parse_init_options(options: str) -> dict[str, Any]:
+    """Parse the init command options into ACRO constructor kwargs."""
+    args: dict[str, Any] = {}
+    found, config = find_brace_word("config", options)
+    if found:
+        assert len(config) == 1, "can only supply one config file name"
+        args["config"] = config[0]
+    found, suppress = find_brace_word("suppress", options)
+    if found:
+        args["suppress"] = suppress
+    found, mitigation = find_brace_word("mitigation", options)
+    if found:
+        assert len(mitigation) == 1, "can only supply one mitigation value"
+        args["mitigation"] = mitigation[0]
+    found, round_base = find_brace_word("round_base", options)
+    if found:
+        assert len(round_base) == 1, "can only supply one round_base value"
+        args["round_base"] = int(round_base[0])
+    return args
+
+
 def run_session_command(command: str, varlist: list[str], options: str) -> str:
     """Run session commands that are data-independent."""
     outcome = ""
 
     if command == "init":
-        args: dict[str, Any] = {}
-        found, config = find_brace_word("config", options)
-        if found:
-            assert len(config) == 1, "can only supply one config file name"
-            args["config"] = config[0]
-        found, suppress = find_brace_word("suppress", options)
-        if found:
-            args["suppress"] = suppress
-        stata_config.stata_acro = ACRO(**args)
+        stata_config.stata_acro = ACRO(**_parse_init_options(options))
         outcome = "acro analysis session created\n"
 
     elif command == "enable_suppression":
@@ -352,6 +367,15 @@ def run_session_command(command: str, varlist: list[str], options: str) -> str:
     elif command == "disable_suppression":
         stata_config.stata_acro.suppress = False
         outcome = "suppression toggled off for subsequent commands"
+    elif command == "enable_rounding":
+        base_arg: int | None = None
+        if varlist:
+            base_arg = int(varlist[0])
+        stata_config.stata_acro.enable_rounding(base_arg)
+        outcome = "rounding toggled on for subsequent commands"
+    elif command == "disable_rounding":
+        stata_config.stata_acro.disable_rounding()
+        outcome = "rounding toggled off for subsequent commands"
     elif command == "finalise":
         suffix = "json"
         out_dir = "stata_outputs"

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -122,15 +122,7 @@ class Tables:
 
     @property
     def suppress(self) -> bool:
-        """
-        Backward-compatible boolean view of the mitigation strategy.
-
-        Reading returns ``True`` iff ``mitigation == "suppress"``. Assigning
-        ``True`` sets mitigation to ``"suppress"``; assigning ``False`` clears
-        mitigation to ``"none"`` only when it was ``"suppress"`` - if rounding
-        is currently active, a ``UserWarning`` is emitted and mitigation is left
-        unchanged (to avoid silently disabling rounding).
-        """
+        """Return True iff the active mitigation strategy is 'suppress'."""
         return self._mitigation == "suppress"
 
     @suppress.setter
@@ -1616,24 +1608,7 @@ def apply_suppression(
 
 
 def round_table(table: DataFrame, base: int) -> DataFrame:
-    """
-    Round every numeric cell of a table to the nearest multiple of ``base``.
-
-    NaN values are preserved. Non-numeric columns are returned unchanged.
-
-    Parameters
-    ----------
-    table : DataFrame
-        The table to round.
-    base : int
-        The rounding base. If not a positive integer the table is returned unchanged.
-
-    Returns
-    -------
-    DataFrame
-        A copy of the table with numeric values rounded to the nearest multiple
-        of ``base``.
-    """
+    """Round numeric cells to the nearest multiple of ``base`` (NaNs preserved)."""
     logger.debug("round_table(base=%s)", base)
     if base is None or base <= 0:
         return table.copy()

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+import warnings
 from collections.abc import Callable
 from inspect import stack
 from typing import Any
@@ -58,19 +59,135 @@ ZEROS_ARE_DISCLOSIVE: bool = True
 # survival analysis parameters
 SURVIVAL_THRESHOLD: int = 10
 
+# default base for the 'round' mitigation strategy
+SAFE_ROUND_BASE: int = 5
+
+# allowed values for the mitigation field
+_ALLOWED_MITIGATIONS: frozenset[str] = frozenset({"none", "suppress", "round"})
+
 
 class Tables:
     """Creates tabular data.
 
     Attributes
     ----------
+    mitigation : str
+        The disclosure-control strategy applied to outputs, one of ``"none"``,
+        ``"suppress"``, ``"round"``.
+    round_base : int
+        The base to round to when ``mitigation == "round"``. Must be a positive integer.
     suppress : bool
-        Whether to automatically apply suppression.
+        Backward-compatible alias. ``True`` is equivalent to ``mitigation == "suppress"``.
     """
 
-    def __init__(self, suppress: bool) -> None:
-        self.suppress: bool = suppress
+    def __init__(
+        self,
+        suppress: bool = False,
+        mitigation: str | None = None,
+        round_base: int | None = None,
+    ) -> None:
+        self._mitigation: str = "none"
+        self._round_base: int = SAFE_ROUND_BASE
+        if round_base is not None:
+            self.round_base = round_base
+        if mitigation is None:
+            mitigation = "suppress" if suppress else "none"
+        self.mitigation = mitigation
         self.results: Records = Records()
+
+    @property
+    def mitigation(self) -> str:
+        """Return the current mitigation strategy."""
+        return self._mitigation
+
+    @mitigation.setter
+    def mitigation(self, value: str) -> None:
+        if value not in _ALLOWED_MITIGATIONS:
+            msg = (
+                f"mitigation must be one of {sorted(_ALLOWED_MITIGATIONS)}, "
+                f"got {value!r}"
+            )
+            raise ValueError(msg)
+        self._mitigation = value
+
+    @property
+    def round_base(self) -> int:
+        """Return the base used by the ``round`` mitigation strategy."""
+        return self._round_base
+
+    @round_base.setter
+    def round_base(self, value: int) -> None:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            msg = "round_base must be a positive integer"
+            raise ValueError(msg)
+        self._round_base = value
+
+    @property
+    def suppress(self) -> bool:
+        """Backward-compatible boolean view of the mitigation strategy.
+
+        Reading returns ``True`` iff ``mitigation == "suppress"``. Assigning
+        ``True`` sets mitigation to ``"suppress"``; assigning ``False`` clears
+        mitigation to ``"none"`` only when it was ``"suppress"`` - if rounding
+        is currently active, a ``UserWarning`` is emitted and mitigation is left
+        unchanged (to avoid silently disabling rounding).
+        """
+        return self._mitigation == "suppress"
+
+    @suppress.setter
+    def suppress(self, value: bool) -> None:
+        if value:
+            self._mitigation = "suppress"
+        elif self._mitigation == "suppress":
+            self._mitigation = "none"
+        elif self._mitigation == "round":
+            warnings.warn(
+                "Setting suppress=False had no effect because mitigation is "
+                "currently 'round'. Use disable_rounding() to turn off rounding.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    def _record_table_output(
+        self,
+        method: str,
+        status: str,
+        sdc: dict,
+        command: str,
+        summary: str,
+        outcome: DataFrame,
+        table: DataFrame,
+        comments: list[str],
+    ) -> None:
+        """Record a table output and attach any mitigation exception note."""
+        properties: dict[str, Any] = {
+            "method": method,
+            "mitigation": self._mitigation,
+        }
+        if self._mitigation == "round":
+            properties["round_base"] = self._round_base
+        self.results.add(
+            status=status,
+            output_type="table",
+            properties=properties,
+            sdc=sdc,
+            command=command,
+            summary=summary,
+            outcome=outcome,
+            output=[table],
+            comments=comments,
+        )
+        if self._mitigation == "suppress":
+            just_added = f"output_{self.results.output_id - 1}"
+            self.results.add_exception(
+                just_added, "Suppression automatically applied where needed"
+            )
+        elif self._mitigation == "round":
+            just_added = f"output_{self.results.output_id - 1}"
+            self.results.add_exception(
+                just_added,
+                f"Rounding automatically applied to nearest {self._round_base}",
+            )
 
     def crosstab(
         self,
@@ -140,6 +257,12 @@ class Tables:
                     "you must also specify a single values column "
                     "to aggregate over."
                 )
+        if margins and self._mitigation == "round":
+            raise ValueError(
+                "margins=True is not allowed when mitigation='round'; "
+                "rounded totals would not add up and constitute a disclosure "
+                "attack vector"
+            )
 
         # convert [list of] string to [list of] function
         agg_func = get_aggfuncs(aggfunc)
@@ -175,12 +298,18 @@ class Tables:
             normalize,
         )
         # build the sdc dictionary
-        sdc: dict = get_table_sdc(masks, self.suppress, table)
+        sdc: dict = get_table_sdc(
+            masks,
+            self.suppress,
+            table,
+            mitigation=self._mitigation,
+            round_base=self._round_base,
+        )
         # get the status and summary
         status, summary = get_summary(sdc)
         # apply the suppression
         safe_table, outcome = apply_suppression(table, masks)
-        if self.suppress:
+        if self._mitigation == "suppress":
             table = safe_table
             if margins:
                 if show_suppressed:
@@ -212,26 +341,26 @@ class Tables:
                         colnames=colnames,
                         normalize=normalize,
                     )
-            sdc = get_table_sdc(masks, self.suppress, table)
+            sdc = get_table_sdc(
+                masks,
+                self.suppress,
+                table,
+                mitigation=self._mitigation,
+                round_base=self._round_base,
+            )
+        elif self._mitigation == "round":
+            table = round_table(table, self._round_base)
 
-        # record output
-
-        self.results.add(
+        self._record_table_output(
+            method="crosstab",
             status=status,
-            output_type="table",
-            properties={"method": "crosstab"},
             sdc=sdc,
             command=command,
             summary=summary,
             outcome=outcome,
-            output=[table],
+            table=table,
             comments=comments,
         )
-        if self.suppress:
-            justadded = f"output_{self.results.output_id - 1}"
-            self.results.add_exception(
-                justadded, "Suppression automatically applied where needed"
-            )
         return table
 
     def pivot_table(
@@ -301,6 +430,13 @@ class Tables:
         """
         logger.debug("pivot_table()")
         command: str = utils.get_command("pivot_table()", stack())
+
+        if margins and self._mitigation == "round":
+            raise ValueError(
+                "margins=True is not allowed when mitigation='round'; "
+                "rounded totals would not add up and constitute a disclosure "
+                "attack vector"
+            )
 
         # Separate variable so param (str|list[str]) isn't reassigned to callable type (mypy)
         resolved_aggfunc: (
@@ -395,12 +531,18 @@ class Tables:
             masks[name] = mask
 
         # build the sdc dictionary
-        sdc: dict = get_table_sdc(masks, self.suppress, table)
+        sdc: dict = get_table_sdc(
+            masks,
+            self.suppress,
+            table,
+            mitigation=self._mitigation,
+            round_base=self._round_base,
+        )
         # get the status and summary
         status, summary = get_summary(sdc)
         # apply the suppression
         safe_table, outcome = apply_suppression(table, masks)
-        if self.suppress:
+        if self._mitigation == "suppress":
             table = safe_table
             if margins:
                 logger.info(
@@ -422,24 +564,25 @@ class Tables:
                     observed=observed,
                     sort=sort,
                 )
-            sdc = get_table_sdc(masks, self.suppress, table)
-        # record output
-        self.results.add(
+            sdc = get_table_sdc(
+                masks,
+                self.suppress,
+                table,
+                mitigation=self._mitigation,
+                round_base=self._round_base,
+            )
+        elif self._mitigation == "round":
+            table = round_table(table, self._round_base)
+        self._record_table_output(
+            method="pivot_table",
             status=status,
-            output_type="table",
-            properties={"method": "pivot_table"},
             sdc=sdc,
             command=command,
             summary=summary,
             outcome=outcome,
-            output=[table],
+            table=table,
             comments=comments,
         )
-        if self.suppress:
-            justadded = f"output_{self.results.output_id - 1}"
-            self.results.add_exception(
-                justadded, "Suppression automatically applied where needed"
-            )
         return table
 
     def surv_func(
@@ -1473,8 +1616,41 @@ def apply_suppression(
     return safe_df, outcome_df
 
 
+def round_table(table: DataFrame, base: int) -> DataFrame:
+    """Round every numeric cell of a table to the nearest multiple of ``base``.
+
+    NaN values are preserved. Non-numeric columns are returned unchanged.
+
+    Parameters
+    ----------
+    table : DataFrame
+        The table to round.
+    base : int
+        The rounding base. If not a positive integer the table is returned unchanged.
+
+    Returns
+    -------
+    DataFrame
+        A copy of the table with numeric values rounded to the nearest multiple
+        of ``base``.
+    """
+    logger.debug("round_table(base=%s)", base)
+    if base is None or base <= 0:
+        return table.copy()
+    numeric = table.select_dtypes(include=["number"])
+    rounded = (numeric / base).round() * base
+    result = table.copy()
+    result[numeric.columns] = rounded
+    return result
+
+
 def get_table_sdc(
-    masks: dict[str, DataFrame], suppress: bool, table: DataFrame | None = None
+    masks: dict[str, DataFrame],
+    suppress: bool,
+    table: DataFrame | None = None,
+    *,
+    mitigation: str | None = None,
+    round_base: int = 0,
 ) -> dict[str, Any]:
     """Return the SDC dictionary using the suppression masks.
 
@@ -1483,14 +1659,29 @@ def get_table_sdc(
     masks : dict[str, DataFrame]
         Dictionary of tables specifying suppression masks for application.
     suppress : bool
-        Whether suppression has been applied.
+        Whether suppression has been applied (legacy flag, kept for
+        back-compat). When ``mitigation`` is provided it takes precedence.
     table : DataFrame, optional
         The table to align masks to.
+    mitigation : str, optional
+        The mitigation strategy applied to the output, one of ``"none"``,
+        ``"suppress"``, ``"round"``. If ``None``, derived from ``suppress``.
+    round_base : int, default 0
+        The base used when ``mitigation == "round"``; ignored otherwise.
     """
+    if mitigation is None:
+        mitigation = "suppress" if suppress else "none"
     if table is not None:
         masks = align_masks(table, masks)
     # summary of cells to be suppressed
-    sdc: dict[str, Any] = {"summary": {"suppressed": suppress}, "cells": {}}
+    sdc: dict[str, Any] = {
+        "summary": {
+            "suppressed": mitigation == "suppress",
+            "mitigation": mitigation,
+            "round_base": round_base if mitigation == "round" else 0,
+        },
+        "cells": {},
+    }
     sdc["summary"]["negative"] = 0
     sdc["summary"]["missing"] = 0
     sdc["summary"]["threshold"] = 0
@@ -1514,6 +1705,21 @@ def get_table_sdc(
     return sdc
 
 
+def _rounded_summary(sdc_summary: dict[str, Any]) -> tuple[str, str]:
+    """Build the status/summary for a rounded output."""
+    status = "review"
+    summary = f"rounded to nearest {sdc_summary.get('round_base', 0)}; "
+    for name in ("threshold", "p-ratio", "nk-rule", "all-values-are-same"):
+        count = sdc_summary.get(name, 0)
+        if count > 0:
+            summary += f"{name}: {count} cells rounded; "
+    if sdc_summary.get("negative", 0) > 0:
+        summary += "negative values found; "
+    if sdc_summary.get("missing", 0) > 0:
+        summary += "missing values found; "
+    return status, f"{status}; {summary}"
+
+
 def get_summary(sdc: dict[str, Any]) -> tuple[str, str]:
     """Return the status and summary of the suppression masks.
 
@@ -1532,6 +1738,13 @@ def get_summary(sdc: dict[str, Any]) -> tuple[str, str]:
     status: str = "pass"
     summary: str = ""
     sdc_summary = sdc["summary"]
+    mitigation: str = sdc_summary.get(
+        "mitigation", "suppress" if sdc_summary.get("suppressed") else "none"
+    )
+    if mitigation == "round":
+        status, summary = _rounded_summary(sdc_summary)
+        logger.info("get_summary(): %s", summary)
+        return status, summary
     sup: str = "suppressed" if sdc_summary["suppressed"] else "may need suppressing"
     if sdc_summary["negative"] > 0:
         summary += "negative values found"

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import secrets
-import warnings
 from collections.abc import Callable
 from inspect import stack
 from typing import Any
@@ -18,6 +17,7 @@ from pandas import DataFrame, Series
 
 from . import utils
 from .record import Records
+from .utils import ALLOWED_MITIGATIONS
 
 logger = logging.getLogger("acro")
 
@@ -62,8 +62,8 @@ SURVIVAL_THRESHOLD: int = 10
 # default base for the 'round' mitigation strategy
 SAFE_ROUND_BASE: int = 5
 
-# allowed values for the mitigation field
-_ALLOWED_MITIGATIONS: frozenset[str] = frozenset({"none", "suppress", "round"})
+# Re-export so existing callers that imported from this module keep working.
+_ALLOWED_MITIGATIONS = ALLOWED_MITIGATIONS
 
 
 class Tables:
@@ -100,12 +100,17 @@ class Tables:
 
     @mitigation.setter
     def mitigation(self, value: str) -> None:
-        if value not in _ALLOWED_MITIGATIONS:
-            msg = (
-                f"mitigation must be one of {sorted(_ALLOWED_MITIGATIONS)}, "
-                f"got {value!r}"
+        if value not in ALLOWED_MITIGATIONS:
+            logger.info(
+                "Sorry, I don't recognise the mitigation %r. "
+                "It should be one of %s. You can turn them on later using "
+                "enable_suppression() or enable_rounding(). "
+                "For now I am proceeding with no mitigation.",
+                value,
+                sorted(ALLOWED_MITIGATIONS),
             )
-            raise ValueError(msg)
+            self._mitigation = "none"
+            return
         self._mitigation = value
 
     @property
@@ -116,8 +121,14 @@ class Tables:
     @round_base.setter
     def round_base(self, value: int) -> None:
         if not isinstance(value, int) or isinstance(value, bool) or value < 1:
-            msg = "round_base must be a positive integer"
-            raise ValueError(msg)
+            logger.info(
+                "round_base must be a positive integer, got %r. "
+                "Falling back to the default value of %d.",
+                value,
+                SAFE_ROUND_BASE,
+            )
+            self._round_base = SAFE_ROUND_BASE
+            return
         self._round_base = value
 
     @property
@@ -132,11 +143,9 @@ class Tables:
         elif self._mitigation == "suppress":
             self._mitigation = "none"
         elif self._mitigation == "round":
-            warnings.warn(
+            logger.info(
                 "Setting suppress=False had no effect because mitigation is "
-                "currently 'round'. Use disable_rounding() to turn off rounding.",
-                UserWarning,
-                stacklevel=2,
+                "currently 'round'. Use disable_rounding() to turn off rounding."
             )
 
     def _record_table_output(
@@ -248,12 +257,12 @@ class Tables:
                     "you must also specify a single values column "
                     "to aggregate over."
                 )
-        if margins and self._mitigation == "round":
-            raise ValueError(
-                "margins=True is not allowed when mitigation='round'; "
-                "rounded totals would not add up and constitute a disclosure "
-                "attack vector"
-            )
+        # When rounding, compute the table without margins first and then
+        # derive margins from the rounded cells (so the inner cells add up
+        # to the displayed totals). See append_rounded_margins() / Jim
+        # Smith's review on PR #381.
+        recompute_margins = margins and self._mitigation == "round"
+        pandas_margins = False if recompute_margins else margins
 
         # convert [list of] string to [list of] function
         agg_func = get_aggfuncs(aggfunc)
@@ -266,7 +275,7 @@ class Tables:
             rownames,
             colnames,
             agg_func,
-            margins,
+            pandas_margins,
             margins_name,
             dropna,
             normalize,
@@ -341,6 +350,10 @@ class Tables:
             )
         elif self._mitigation == "round":
             table = round_table(table, self._round_base)
+            if recompute_margins:
+                table = append_rounded_margins(
+                    table, agg_func, margins_name, self._round_base
+                )
 
         self._record_table_output(
             method="crosstab",
@@ -422,12 +435,11 @@ class Tables:
         logger.debug("pivot_table()")
         command: str = utils.get_command("pivot_table()", stack())
 
-        if margins and self._mitigation == "round":
-            raise ValueError(
-                "margins=True is not allowed when mitigation='round'; "
-                "rounded totals would not add up and constitute a disclosure "
-                "attack vector"
-            )
+        # When rounding, compute the table without pandas-managed margins
+        # and re-derive them from the rounded cells; see append_rounded_margins()
+        # / Jim Smith's review on PR #381.
+        recompute_margins = margins and self._mitigation == "round"
+        pandas_margins = False if recompute_margins else margins
 
         # Separate variable so param (str|list[str]) isn't reassigned to callable type (mypy)
         resolved_aggfunc: (
@@ -445,7 +457,7 @@ class Tables:
             columns,
             resolved_aggfunc,
             fill_value,
-            margins,
+            pandas_margins,
             dropna,
             margins_name,
             observed,
@@ -564,6 +576,10 @@ class Tables:
             )
         elif self._mitigation == "round":
             table = round_table(table, self._round_base)
+            if recompute_margins:
+                table = append_rounded_margins(
+                    table, resolved_aggfunc, margins_name, self._round_base
+                )
         self._record_table_output(
             method="pivot_table",
             status=status,
@@ -1617,6 +1633,90 @@ def round_table(table: DataFrame, base: int) -> DataFrame:
     result = table.copy()
     result[numeric.columns] = rounded
     return result
+
+
+def _aggfunc_name(aggfunc: Any) -> str | None:
+    """Return a string name for an aggfunc value, or None if not derivable."""
+    if isinstance(aggfunc, str):
+        return aggfunc
+    if callable(aggfunc) and hasattr(aggfunc, "__name__"):
+        return aggfunc.__name__
+    return None
+
+
+def append_rounded_margins(
+    rounded_table: DataFrame,
+    aggfunc: Any,
+    margins_name: str,
+    base: int,
+) -> DataFrame:
+    """Append row/column/grand-total margins to a pre-rounded table.
+
+    Following Jim Smith's review on PR #381: once cells have been rounded,
+    margins are computed by aggregating the rounded cells (so rounded inner
+    cells add up to the displayed totals) and then rounded again to ``base``
+    so the whole output respects the rounding base.
+
+    Conceptually this is the same as the "synthetic-data" approach Jim
+    described - exploding the rounded table into one record per cell and
+    re-running ``pd.crosstab(margins=True)`` - but implemented directly on
+    the rounded DataFrame to keep it simple. We currently support single-
+    level row and column indices; multi-level or list-of-aggfunc tables fall
+    back to returning the table without margins.
+    """
+    if isinstance(aggfunc, list):
+        logger.info(
+            "Cannot add margins to a rounded table when multiple aggregation "
+            "functions were requested; returning the table without margins."
+        )
+        return rounded_table
+    if rounded_table.index.nlevels > 1 or rounded_table.columns.nlevels > 1:
+        logger.info(
+            "Margin recomputation for hierarchical row/column indexes is not "
+            "yet supported under rounding; returning the table without margins."
+        )
+        return rounded_table
+
+    name = _aggfunc_name(aggfunc)
+    if aggfunc is None or name in (None, "count", "sum", "mode_aggfunc"):
+        agg_method = "sum"
+    elif name == "mean":
+        agg_method = "mean"
+    elif name == "median":
+        agg_method = "median"
+    else:
+        logger.info(
+            "Margin recomputation for aggfunc %r is not supported under "
+            "rounding; returning the table without margins.",
+            name,
+        )
+        return rounded_table
+
+    numeric = rounded_table.select_dtypes(include=["number"])
+    if agg_method == "sum":
+        row_margin = numeric.sum(axis=1, skipna=True)
+        col_margin = numeric.sum(axis=0, skipna=True)
+        grand = float(numeric.to_numpy(dtype=float, na_value=0.0).sum())
+    elif agg_method == "mean":
+        row_margin = numeric.mean(axis=1, skipna=True)
+        col_margin = numeric.mean(axis=0, skipna=True)
+        grand = float(numeric.stack().mean())
+    else:  # median
+        row_margin = numeric.median(axis=1, skipna=True)
+        col_margin = numeric.median(axis=0, skipna=True)
+        grand = float(numeric.stack().median())
+
+    if base and base > 0:
+        row_margin = (row_margin / base).round() * base
+        col_margin = (col_margin / base).round() * base
+        grand = round(grand / base) * base
+
+    table = rounded_table.copy()
+    table[margins_name] = row_margin
+    new_row = col_margin.reindex(table.columns)
+    new_row[margins_name] = grand
+    table.loc[margins_name] = new_row
+    return table
 
 
 def get_table_sdc(

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -1693,18 +1693,9 @@ def append_rounded_margins(
         return rounded_table
 
     numeric = rounded_table.select_dtypes(include=["number"])
-    if agg_method == "sum":
-        row_margin = numeric.sum(axis=1, skipna=True)
-        col_margin = numeric.sum(axis=0, skipna=True)
-        grand = float(numeric.to_numpy(dtype=float, na_value=0.0).sum())
-    elif agg_method == "mean":
-        row_margin = numeric.mean(axis=1, skipna=True)
-        col_margin = numeric.mean(axis=0, skipna=True)
-        grand = float(numeric.stack().mean())
-    else:  # median
-        row_margin = numeric.median(axis=1, skipna=True)
-        col_margin = numeric.median(axis=0, skipna=True)
-        grand = float(numeric.stack().median())
+    row_margin = getattr(numeric, agg_method)(axis=1, skipna=True)
+    col_margin = getattr(numeric, agg_method)(axis=0, skipna=True)
+    grand = float(getattr(numeric.stack(), agg_method)())
 
     if base and base > 0:
         row_margin = (row_margin / base).round() * base

--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -84,12 +84,10 @@ class Tables:
         self,
         suppress: bool = False,
         mitigation: str | None = None,
-        round_base: int | None = None,
     ) -> None:
+        """Initialise a Tables instance with the chosen mitigation strategy."""
         self._mitigation: str = "none"
         self._round_base: int = SAFE_ROUND_BASE
-        if round_base is not None:
-            self.round_base = round_base
         if mitigation is None:
             mitigation = "suppress" if suppress else "none"
         self.mitigation = mitigation
@@ -124,7 +122,8 @@ class Tables:
 
     @property
     def suppress(self) -> bool:
-        """Backward-compatible boolean view of the mitigation strategy.
+        """
+        Backward-compatible boolean view of the mitigation strategy.
 
         Reading returns ``True`` iff ``mitigation == "suppress"``. Assigning
         ``True`` sets mitigation to ``"suppress"``; assigning ``False`` clears
@@ -1617,7 +1616,8 @@ def apply_suppression(
 
 
 def round_table(table: DataFrame, base: int) -> DataFrame:
-    """Round every numeric cell of a table to the nearest multiple of ``base``.
+    """
+    Round every numeric cell of a table to the nearest multiple of ``base``.
 
     NaN values are preserved. Non-numeric columns are returned unchanged.
 

--- a/acro/default.yaml
+++ b/acro/default.yaml
@@ -29,4 +29,7 @@ survival_safe_threshold: 10
 
 # consider zeros to be disclosive
 zeros_are_disclosive: True
+
+# default rounding base for the 'round' mitigation strategy on tables
+safe_round_base: 5
 ...

--- a/acro/utils.py
+++ b/acro/utils.py
@@ -9,6 +9,11 @@ import pandas as pd
 
 logger = logging.getLogger("acro")
 
+# Allowed values for the disclosure-control ``mitigation`` field.
+# Lives here so both :mod:`acro.acro_tables` and :mod:`acro.acro_stata_parser`
+# can share a single source of truth.
+ALLOWED_MITIGATIONS: frozenset[str] = frozenset({"none", "suppress", "round"})
+
 
 def get_command(default: str, stack_list: list[FrameInfo]) -> str:
     """Return the calling source line as a string.

--- a/docs/ACRO_For_Researchers.md
+++ b/docs/ACRO_For_Researchers.md
@@ -40,7 +40,7 @@ acro.enable_rounding(base=5)
 acro.disable_rounding()
 ```
 
-Row and column totals (`margins=True`) are **not allowed** when rounding is active — rounded inner cells would not add up to rounded totals, and the mismatch is a known disclosure attack vector. Passing `margins=True` while `mitigation == "round"` raises a `ValueError`.
+Row and column totals (`margins=True`) are supported under rounding. To avoid the "rounded inner cells don't add up to the displayed totals" mismatch (a known disclosure attack vector), the margins are recomputed from the *rounded* inner cells and then re-rounded to `round_base`, so what the researcher sees is internally consistent. A small set of cases (list-of-aggfunc tables, multi-level row/column indexes, and aggfuncs other than `sum`/`mean`/`median`) currently fall back to returning the table without margins and log a message explaining why.
 
 The audit record (the `sdc` dictionary attached to each output) still contains the full, unrounded disclosure-check results, so output checkers can see the underlying risk even though the released table shows rounded values.
 

--- a/docs/ACRO_For_Researchers.md
+++ b/docs/ACRO_For_Researchers.md
@@ -27,6 +27,23 @@ The suppress option lets you control whether disclosive outputs are automaticall
 
 After initialising the ACRO object the TRE risk appetite will be displayed on the screen to show you the default parameters for the disclosure tests defined by the TRE.
 
+#### Mitigation strategies: `suppress` vs `round`
+ACRO offers two automatic disclosure-control strategies for tables (`crosstab` and `pivot_table`):
+- **`suppress`** (default behaviour of `acro.suppress = True`): individual cells that fail a disclosure check are replaced with `NaN`. Adds highly targeted uncertainty.
+- **`round`**: all cell values are rounded to the nearest `round_base` (default 5). Spreads small amounts of uncertainty across the entire table rather than concentrating it on a few cells.
+
+```python
+acro = ACRO(mitigation="round", round_base=5)
+# or on an existing session:
+acro.enable_rounding(base=5)
+# to stop:
+acro.disable_rounding()
+```
+
+Row and column totals (`margins=True`) are **not allowed** when rounding is active — rounded inner cells would not add up to rounded totals, and the mismatch is a known disclosure attack vector. Passing `margins=True` while `mitigation == "round"` raises a `ValueError`.
+
+The audit record (the `sdc` dictionary attached to each output) still contains the full, unrounded disclosure-check results, so output checkers can see the underlying risk even though the released table shows rounded values.
+
 ### Step 2: Producing your outputs with the acro prefix
 All the commands for producing analyses will automatically add the output to the acro object you created in step 1.
 

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1615,3 +1615,20 @@ def test_rounded_summary_reports_negative_values(data):
     acro.crosstab(data.year, data.grant_type, values=data.inc_grants, aggfunc="mean")
     output = acro.results.get_index(0)
     assert "negative values found" in output.summary
+
+
+def test_rounded_summary_reports_missing_values():
+    """_rounded_summary emits a missing-values note when the check fires."""
+    sdc_summary = {
+        "mitigation": "round",
+        "round_base": 5,
+        "threshold": 0,
+        "p-ratio": 0,
+        "nk-rule": 0,
+        "all-values-are-same": 0,
+        "negative": 0,
+        "missing": 2,
+    }
+    status, summary = acro_tables._rounded_summary(sdc_summary)
+    assert status == "review"
+    assert "missing values found" in summary

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1660,3 +1660,79 @@ def test_rounded_summary_reports_missing_values():
     status, summary = acro_tables._rounded_summary(sdc_summary)
     assert status == "review"
     assert "missing values found" in summary
+
+
+def _simple_rounded_table() -> pd.DataFrame:
+    """Return a small pre-rounded numeric table for margin tests."""
+    return pd.DataFrame(
+        {"a": [5.0, 10.0, 15.0], "b": [10.0, 5.0, 20.0]},
+        index=["r1", "r2", "r3"],
+    )
+
+
+def test_aggfunc_name_extracts_callable_name():
+    """_aggfunc_name returns __name__ for callables and None for opaque values."""
+    assert acro_tables._aggfunc_name("mean") == "mean"
+    assert acro_tables._aggfunc_name(acro_tables.mode_aggfunc) == "mode_aggfunc"
+    assert acro_tables._aggfunc_name(object()) is None
+
+
+def test_append_rounded_margins_list_aggfunc_skips_margins(caplog):
+    """A list of aggfuncs falls back to no margins with a log message."""
+    table = _simple_rounded_table()
+    with caplog.at_level(logging.INFO, logger="acro"):
+        result = acro_tables.append_rounded_margins(table, ["sum", "mean"], "All", 5)
+    pd.testing.assert_frame_equal(result, table)
+    assert "multiple aggregation" in caplog.text
+
+
+def test_append_rounded_margins_multilevel_index_skips_margins(caplog):
+    """A hierarchical row index falls back to no margins."""
+    idx = pd.MultiIndex.from_tuples([("a", 1), ("a", 2), ("b", 1)])
+    table = pd.DataFrame({"x": [5.0, 10.0, 15.0], "y": [10.0, 5.0, 20.0]}, index=idx)
+    with caplog.at_level(logging.INFO, logger="acro"):
+        result = acro_tables.append_rounded_margins(table, None, "All", 5)
+    pd.testing.assert_frame_equal(result, table)
+    assert "hierarchical" in caplog.text
+
+
+def test_append_rounded_margins_multilevel_columns_skips_margins(caplog):
+    """A hierarchical column index falls back to no margins."""
+    cols = pd.MultiIndex.from_tuples([("g", "x"), ("g", "y")])
+    table = pd.DataFrame([[5.0, 10.0], [10.0, 5.0]], columns=cols)
+    with caplog.at_level(logging.INFO, logger="acro"):
+        result = acro_tables.append_rounded_margins(table, None, "All", 5)
+    pd.testing.assert_frame_equal(result, table)
+    assert "hierarchical" in caplog.text
+
+
+def test_append_rounded_margins_unsupported_aggfunc_skips_margins(caplog):
+    """An aggfunc we don't know how to recompute margins for is skipped."""
+    table = _simple_rounded_table()
+    with caplog.at_level(logging.INFO, logger="acro"):
+        result = acro_tables.append_rounded_margins(table, "std", "All", 5)
+    pd.testing.assert_frame_equal(result, table)
+    assert "'std'" in caplog.text
+
+
+def test_append_rounded_margins_mean_uses_mean_of_rounded_cells():
+    """Mean aggfunc derives margins from the mean of rounded cells, then rounds them."""
+    table = _simple_rounded_table()
+    result = acro_tables.append_rounded_margins(table, "mean", "All", 5)
+    # mean of row r1 = mean(5, 10) = 7.5; pandas Series.round uses banker's
+    # rounding so 7.5/5=1.5 -> 2 -> 10.
+    assert result.loc["r1", "All"] == 10
+    # mean of column a = mean(5, 10, 15) = 10
+    assert result.loc["All", "a"] == 10
+    values = _rounded_cells(result)
+    assert np.all(values % 5 == 0)
+
+
+def test_append_rounded_margins_median_uses_median_of_rounded_cells():
+    """Median aggfunc derives margins from the median of rounded cells."""
+    table = _simple_rounded_table()
+    result = acro_tables.append_rounded_margins(table, "median", "All", 5)
+    # median of column a = median(5, 10, 15) = 10
+    assert result.loc["All", "a"] == 10
+    values = _rounded_cells(result)
+    assert np.all(values % 5 == 0)

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1570,6 +1570,18 @@ def test_enable_rounding_disable_rounding():
     assert acro.mitigation == "none"
 
 
+def test_disable_rounding_does_not_restore_prior_suppress():
+    """Disable_rounding always falls back to 'none', not to prior suppress=True."""
+    acro = ACRO(suppress=True)
+    assert acro.mitigation == "suppress"
+    acro.enable_rounding()
+    assert acro.mitigation == "round"
+    acro.disable_rounding()
+    # documented behaviour: prior suppress state is not restored
+    assert acro.mitigation == "none"
+    assert acro.suppress is False
+
+
 def test_round_base_loaded_from_config():
     """Round_base is picked up from the yaml config by default."""
     acro = ACRO()

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1452,6 +1452,30 @@ def _rounded_cells(table: pd.DataFrame) -> np.ndarray:
     return numeric[~np.isnan(numeric)]
 
 
+def _assert_rounded_margins_consistent(
+    table: pd.DataFrame, base: int, margins_name: str = "All"
+) -> None:
+    """Assert every margin equals the rounded sum of the rounded inner cells.
+
+    Checks row totals, column totals, and the grand total along both axes.
+    """
+    inner_cols = [c for c in table.columns if c != margins_name]
+    inner_rows = [r for r in table.index if r != margins_name]
+    # row margins: sum across inner columns, re-rounded
+    for row in inner_rows:
+        expected = (table.loc[row, inner_cols].sum() / base).round() * base
+        assert table.loc[row, margins_name] == expected
+    # column margins: sum across inner rows, re-rounded
+    for col in inner_cols:
+        expected = (table.loc[inner_rows, col].sum() / base).round() * base
+        assert table.loc[margins_name, col] == expected
+    # grand total: rounded sum of the column margins == rounded sum of the row margins
+    grand_from_cols = (table.loc[margins_name, inner_cols].sum() / base).round() * base
+    grand_from_rows = (table.loc[inner_rows, margins_name].sum() / base).round() * base
+    assert table.loc[margins_name, margins_name] == grand_from_cols
+    assert table.loc[margins_name, margins_name] == grand_from_rows
+
+
 def test_crosstab_with_rounding_base_5(data):
     """Crosstab with mitigation='round' rounds every cell to nearest 5."""
     acro = ACRO(mitigation="round")
@@ -1502,12 +1526,8 @@ def test_rounding_with_margins_crosstab_recomputes_totals(data):
     values = _rounded_cells(table)
     assert values.size > 0
     assert np.all(values % 5 == 0)
-    # the recomputed row margin equals the sum of the rounded inner cells
-    inner_cols = [c for c in table.columns if c != "All"]
-    inner_rows = [r for r in table.index if r != "All"]
-    for row in inner_rows:
-        expected = (table.loc[row, inner_cols].sum() / 5).round() * 5
-        assert table.loc[row, "All"] == expected
+    # row totals, column totals, and the grand total are all consistent
+    _assert_rounded_margins_consistent(table, base=5)
 
 
 def test_rounding_with_margins_pivot_table_recomputes_totals(data):

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1,6 +1,7 @@
 """Unit tests."""
 
 import json
+import logging
 import os
 import shutil
 from unittest.mock import patch
@@ -1490,25 +1491,41 @@ def test_pivot_table_with_rounding(data):
     assert output.properties["round_base"] == 5
 
 
-def test_rounding_with_margins_raises_crosstab(data):
-    """Crosstab raises ValueError when margins=True and mitigation='round'."""
-    acro = ACRO(mitigation="round")
-    with pytest.raises(ValueError, match="margins=True is not allowed"):
-        acro.crosstab(data.year, data.grant_type, margins=True)
+def test_rounding_with_margins_crosstab_recomputes_totals(data):
+    """Crosstab with margins=True under rounding recomputes margins from rounded cells."""
+    acro = ACRO(mitigation="round", round_base=5)
+    table = acro.crosstab(data.year, data.grant_type, margins=True)
+    # margins row/column are present and named "All"
+    assert "All" in table.columns
+    assert "All" in table.index
+    # every cell (including margins) is a multiple of the round base
+    values = _rounded_cells(table)
+    assert values.size > 0
+    assert np.all(values % 5 == 0)
+    # the recomputed row margin equals the sum of the rounded inner cells
+    inner_cols = [c for c in table.columns if c != "All"]
+    inner_rows = [r for r in table.index if r != "All"]
+    for row in inner_rows:
+        expected = (table.loc[row, inner_cols].sum() / 5).round() * 5
+        assert table.loc[row, "All"] == expected
 
 
-def test_rounding_with_margins_raises_pivot_table(data):
-    """Pivot_table raises ValueError when margins=True and mitigation='round'."""
-    acro = ACRO(mitigation="round")
-    with pytest.raises(ValueError, match="margins=True is not allowed"):
-        acro.pivot_table(
-            data,
-            index="year",
-            columns="grant_type",
-            values="inc_grants",
-            aggfunc="count",
-            margins=True,
-        )
+def test_rounding_with_margins_pivot_table_recomputes_totals(data):
+    """Pivot_table with margins=True under rounding recomputes margins from rounded cells."""
+    acro = ACRO(mitigation="round", round_base=5)
+    table = acro.pivot_table(
+        data,
+        index="year",
+        columns="grant_type",
+        values="inc_grants",
+        aggfunc="count",
+        margins=True,
+    )
+    assert "All" in table.columns
+    assert "All" in table.index
+    values = _rounded_cells(table)
+    assert values.size > 0
+    assert np.all(values % 5 == 0)
 
 
 def test_suppress_backward_compat():
@@ -1552,24 +1569,33 @@ def test_round_preserves_nan():
     assert rounded.loc[1, "b"] == 0
 
 
-def test_round_base_rejects_non_positive():
-    """Setting round_base to zero or negative raises ValueError."""
+def test_round_base_rejects_non_positive(caplog):
+    """Setting round_base to zero or negative logs a message and falls back to default."""
     acro = ACRO()
-    with pytest.raises(ValueError, match="positive integer"):
+    default = acro.round_base
+    with caplog.at_level(logging.INFO, logger="acro"):
         acro.round_base = 0
-    with pytest.raises(ValueError, match="positive integer"):
+    assert acro.round_base == default
+    assert "positive integer" in caplog.text
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="acro"):
         acro.round_base = -3
+    assert acro.round_base == default
+    assert "positive integer" in caplog.text
 
 
-def test_suppress_false_while_rounding_is_noop():
-    """Setting suppress=False while rounding is active warns and is a no-op."""
+def test_suppress_false_while_rounding_is_noop(caplog):
+    """Setting suppress=False while rounding is active logs a message and is a no-op."""
     acro = ACRO(mitigation="round")
-    with pytest.warns(UserWarning, match="disable_rounding"):
+    with caplog.at_level(logging.INFO, logger="acro"):
         acro.suppress = False
     assert acro.mitigation == "round"
-    with pytest.warns(UserWarning, match="disable_rounding"):
+    assert "disable_rounding" in caplog.text
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="acro"):
         acro.disable_suppression()
     assert acro.mitigation == "round"
+    assert "disable_rounding" in caplog.text
 
 
 def test_rounding_records_underlying_disclosure_risk(data):
@@ -1592,11 +1618,13 @@ def test_round_base_passed_to_constructor():
     assert acro.round_base == 7
 
 
-def test_mitigation_setter_rejects_invalid_value():
-    """Setting mitigation to an unknown value raises ValueError."""
+def test_mitigation_setter_rejects_invalid_value(caplog):
+    """Setting mitigation to an unknown value logs a message and falls back to 'none'."""
     acro = ACRO()
-    with pytest.raises(ValueError, match="mitigation must be one of"):
+    with caplog.at_level(logging.INFO, logger="acro"):
         acro.mitigation = "obfuscate"
+    assert acro.mitigation == "none"
+    assert "obfuscate" in caplog.text
 
 
 def test_round_table_noop_when_base_non_positive():

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1443,3 +1443,175 @@ def test_cell_id_alignment_with_margins_and_suppression(data):
                 assert pd.isna(value), (
                     f"Cell at ({row}, {col}) in {cell_type} should be NaN but is {value}"
                 )
+
+
+def _rounded_cells(table: pd.DataFrame) -> np.ndarray:
+    """Return the non-NaN numeric values of a table as a flat numpy array."""
+    numeric = table.select_dtypes(include=["number"]).to_numpy().ravel()
+    return numeric[~np.isnan(numeric)]
+
+
+def test_crosstab_with_rounding_base_5(data):
+    """Crosstab with mitigation='round' rounds every cell to nearest 5."""
+    acro = ACRO(mitigation="round")
+    table = acro.crosstab(data.year, data.grant_type)
+    values = _rounded_cells(table)
+    assert values.size > 0
+    assert np.all(values % 5 == 0)
+    output = acro.results.get_index(0)
+    assert output.status == "review"
+    assert "rounded to nearest 5" in output.summary
+    assert output.properties["mitigation"] == "round"
+    assert output.properties["round_base"] == 5
+
+
+def test_crosstab_with_rounding_base_10(data):
+    """Crosstab with round_base=10 rounds every cell to nearest 10."""
+    acro = ACRO(mitigation="round", round_base=10)
+    table = acro.crosstab(data.year, data.grant_type)
+    values = _rounded_cells(table)
+    assert values.size > 0
+    assert np.all(values % 10 == 0)
+    output = acro.results.get_index(0)
+    assert "rounded to nearest 10" in output.summary
+
+
+def test_pivot_table_with_rounding(data):
+    """Pivot_table with mitigation='round' rounds every cell."""
+    acro = ACRO(mitigation="round", round_base=5)
+    table = acro.pivot_table(
+        data, index="year", columns="grant_type", values="inc_grants", aggfunc="count"
+    )
+    values = _rounded_cells(table)
+    assert values.size > 0
+    assert np.all(values % 5 == 0)
+    output = acro.results.get_index(0)
+    assert output.properties["mitigation"] == "round"
+    assert output.properties["round_base"] == 5
+
+
+def test_rounding_with_margins_raises_crosstab(data):
+    """Crosstab raises ValueError when margins=True and mitigation='round'."""
+    acro = ACRO(mitigation="round")
+    with pytest.raises(ValueError, match="margins=True is not allowed"):
+        acro.crosstab(data.year, data.grant_type, margins=True)
+
+
+def test_rounding_with_margins_raises_pivot_table(data):
+    """Pivot_table raises ValueError when margins=True and mitigation='round'."""
+    acro = ACRO(mitigation="round")
+    with pytest.raises(ValueError, match="margins=True is not allowed"):
+        acro.pivot_table(
+            data,
+            index="year",
+            columns="grant_type",
+            values="inc_grants",
+            aggfunc="count",
+            margins=True,
+        )
+
+
+def test_suppress_backward_compat():
+    """The suppress property stays in sync with mitigation."""
+    acro = ACRO(suppress=True)
+    assert acro.mitigation == "suppress"
+    assert acro.suppress is True
+    acro.suppress = False
+    assert acro.mitigation == "none"
+    assert acro.suppress is False
+    acro.suppress = True
+    assert acro.mitigation == "suppress"
+
+
+def test_enable_rounding_disable_rounding():
+    """Enable_rounding / disable_rounding toggle the mitigation field."""
+    acro = ACRO()
+    assert acro.mitigation == "none"
+    acro.enable_rounding(base=10)
+    assert acro.mitigation == "round"
+    assert acro.round_base == 10
+    acro.disable_rounding()
+    assert acro.mitigation == "none"
+
+
+def test_round_base_loaded_from_config():
+    """Round_base is picked up from the yaml config by default."""
+    acro = ACRO()
+    assert acro.round_base == 5
+
+
+def test_round_preserves_nan():
+    """Rounding a table with NaN cells preserves the NaN."""
+    table = pd.DataFrame({"a": [3.0, np.nan, 11.0], "b": [7.0, 2.0, np.nan]})
+    rounded = acro_tables.round_table(table, base=5)
+    assert pd.isna(rounded.loc[1, "a"])
+    assert pd.isna(rounded.loc[2, "b"])
+    assert rounded.loc[0, "a"] == 5
+    assert rounded.loc[2, "a"] == 10
+    assert rounded.loc[0, "b"] == 5
+    assert rounded.loc[1, "b"] == 0
+
+
+def test_round_base_rejects_non_positive():
+    """Setting round_base to zero or negative raises ValueError."""
+    acro = ACRO()
+    with pytest.raises(ValueError, match="positive integer"):
+        acro.round_base = 0
+    with pytest.raises(ValueError, match="positive integer"):
+        acro.round_base = -3
+
+
+def test_suppress_false_while_rounding_is_noop():
+    """Setting suppress=False while rounding is active warns and is a no-op."""
+    acro = ACRO(mitigation="round")
+    with pytest.warns(UserWarning, match="disable_rounding"):
+        acro.suppress = False
+    assert acro.mitigation == "round"
+    with pytest.warns(UserWarning, match="disable_rounding"):
+        acro.disable_suppression()
+    assert acro.mitigation == "round"
+
+
+def test_rounding_records_underlying_disclosure_risk(data):
+    """The sdc audit record still flags threshold violations when rounding."""
+    acro = ACRO(mitigation="round", round_base=5)
+    acro.crosstab(data.year, data.grant_type)
+    output = acro.results.get_index(0)
+    assert output.sdc["summary"]["threshold"] > 0
+    assert output.sdc["summary"]["mitigation"] == "round"
+    assert output.sdc["summary"]["round_base"] == 5
+    assert "rounded to nearest 5" in output.summary
+    assert "threshold:" in output.summary
+    values = _rounded_cells(output.output[0])
+    assert np.all(values % 5 == 0)
+
+
+def test_round_base_passed_to_constructor():
+    """ACRO(round_base=...) overrides the yaml default."""
+    acro = ACRO(round_base=7)
+    assert acro.round_base == 7
+
+
+def test_mitigation_setter_rejects_invalid_value():
+    """Setting mitigation to an unknown value raises ValueError."""
+    acro = ACRO()
+    with pytest.raises(ValueError, match="mitigation must be one of"):
+        acro.mitigation = "obfuscate"
+
+
+def test_round_table_noop_when_base_non_positive():
+    """Round_table returns an unchanged copy when base is 0 or negative."""
+    table = pd.DataFrame({"a": [3.2, 4.7], "b": [11.0, 9.0]})
+    zero = acro_tables.round_table(table, base=0)
+    assert (zero.to_numpy() == table.to_numpy()).all()
+    negative = acro_tables.round_table(table, base=-5)
+    assert (negative.to_numpy() == table.to_numpy()).all()
+
+
+def test_rounded_summary_reports_negative_values(data):
+    """The rounded summary surfaces negative and missing check results."""
+    data.loc[0:10, "inc_grants"] = -10
+    acro = ACRO(mitigation="round", round_base=5)
+    acro.crosstab(data.year, data.grant_type, values=data.inc_grants, aggfunc="mean")
+    output = acro.results.get_index(0)
+    assert "negative values found" in output.summary

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1546,6 +1546,8 @@ def test_rounding_with_margins_pivot_table_recomputes_totals(data):
     values = _rounded_cells(table)
     assert values.size > 0
     assert np.all(values % 5 == 0)
+    # row totals, column totals, and the grand total are all consistent
+    _assert_rounded_margins_consistent(table, base=5)
 
 
 def test_suppress_backward_compat():

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1455,10 +1455,7 @@ def _rounded_cells(table: pd.DataFrame) -> np.ndarray:
 def _assert_rounded_margins_consistent(
     table: pd.DataFrame, base: int, margins_name: str = "All"
 ) -> None:
-    """Assert every margin equals the rounded sum of the rounded inner cells.
-
-    Checks row totals, column totals, and the grand total along both axes.
-    """
+    """Assert margins equal rounded sums of inner cells across both axes."""
     inner_cols = [c for c in table.columns if c != margins_name]
     inner_rows = [r for r in table.index if r != margins_name]
     # row margins: sum across inner columns, re-rounded

--- a/test/test_stata_interface.py
+++ b/test/test_stata_interface.py
@@ -963,6 +963,69 @@ def test_stata_unknown(data):
     assert ret == correct, f"got:\n{ret}\nexpected:\n{correct}\n"
 
 
+def test_stata_acro_init_with_mitigation_and_round_base(data):
+    """Init parses mitigation and round_base options."""
+    stata_config.stata_acro = "empty"
+    ret = dummy_acrohandler(
+        data,
+        command="init",
+        varlist="",
+        exclusion="",
+        exp="",
+        weights="",
+        options="mitigation(round) round_base(7)",
+        stata_version="17",
+    )
+    assert ret == "acro analysis session created\n"
+    assert isinstance(stata_config.stata_acro, ACRO)
+    assert stata_config.stata_acro.mitigation == "round"
+    assert stata_config.stata_acro.round_base == 7
+
+
+def test_stata_acro_enable_rounding(data):
+    """Enable_rounding stata command toggles mitigation to round."""
+    stata_config.stata_acro = "empty"
+    dummy_acrohandler(
+        data,
+        command="init",
+        varlist="",
+        exclusion="",
+        exp="",
+        weights="",
+        options="",
+        stata_version="17",
+    )
+    ret = dummy_acrohandler(
+        data,
+        "enable_rounding",
+        varlist="10",
+        exclusion="",
+        exp="",
+        weights="",
+        options="",
+        stata_version="17",
+    )
+    assert ret == "rounding toggled on for subsequent commands"
+    assert stata_config.stata_acro.mitigation == "round"
+    assert stata_config.stata_acro.round_base == 10
+
+
+def test_stata_acro_disable_rounding(data):
+    """Disable_rounding stata command clears the round mitigation."""
+    ret = dummy_acrohandler(
+        data,
+        "disable_rounding",
+        varlist="",
+        exclusion="",
+        exp="",
+        weights="",
+        options="",
+        stata_version="17",
+    )
+    assert ret == "rounding toggled off for subsequent commands"
+    assert stata_config.stata_acro.mitigation == "none"
+
+
 def test_cleanup():
     """Remove files created during tests."""
     names = ["test_outputs", "test_add_to_acro", "sdc_results", "RES_PYTEST"]

--- a/test/test_stata_interface.py
+++ b/test/test_stata_interface.py
@@ -1,6 +1,7 @@
 """Unit tests for the stata interface."""
 
 import copy
+import logging
 import os
 import shutil
 
@@ -1024,6 +1025,76 @@ def test_stata_acro_disable_rounding(data):
     )
     assert ret == "rounding toggled off for subsequent commands"
     assert stata_config.stata_acro.mitigation == "none"
+
+
+def test_stata_acro_init_invalid_mitigation(data, caplog):
+    """Init with an unrecognised mitigation falls back to 'none' with a log message."""
+    stata_config.stata_acro = "empty"
+    with caplog.at_level(logging.INFO, logger="acro"):
+        ret = dummy_acrohandler(
+            data,
+            command="init",
+            varlist="",
+            exclusion="",
+            exp="",
+            weights="",
+            options="mitigation(obfuscate)",
+            stata_version="17",
+        )
+    assert ret == "acro analysis session created\n"
+    assert stata_config.stata_acro.mitigation == "none"
+    assert "obfuscate" in caplog.text
+
+
+def test_stata_acro_init_invalid_round_base(data, caplog):
+    """Init with a non-integer round_base logs a message and uses the default."""
+    stata_config.stata_acro = "empty"
+    with caplog.at_level(logging.INFO, logger="acro"):
+        ret = dummy_acrohandler(
+            data,
+            command="init",
+            varlist="",
+            exclusion="",
+            exp="",
+            weights="",
+            options="mitigation(round) round_base(notanumber)",
+            stata_version="17",
+        )
+    assert ret == "acro analysis session created\n"
+    assert stata_config.stata_acro.mitigation == "round"
+    assert stata_config.stata_acro.round_base == 5
+    assert "notanumber" in caplog.text
+
+
+def test_stata_acro_enable_rounding_invalid_base(data, caplog):
+    """Enable_rounding with a non-integer base logs a message and uses the default."""
+    stata_config.stata_acro = "empty"
+    dummy_acrohandler(
+        data,
+        command="init",
+        varlist="",
+        exclusion="",
+        exp="",
+        weights="",
+        options="",
+        stata_version="17",
+    )
+    default_base = stata_config.stata_acro.round_base
+    with caplog.at_level(logging.INFO, logger="acro"):
+        ret = dummy_acrohandler(
+            data,
+            "enable_rounding",
+            varlist="banana",
+            exclusion="",
+            exp="",
+            weights="",
+            options="",
+            stata_version="17",
+        )
+    assert ret == "rounding toggled on for subsequent commands"
+    assert stata_config.stata_acro.mitigation == "round"
+    assert stata_config.stata_acro.round_base == default_base
+    assert "banana" in caplog.text
 
 
 def test_cleanup():


### PR DESCRIPTION
Adds a `mitigation` field on ACRO/Tables: `"none"`, `"suppress"`, or `"round"`. `"round"` rounds every cell of `crosstab` / `pivot_table` output to the nearest `round_base` (default 5, set via `safe_round_base` in the yaml).

The old `suppress` bool, `enable_suppression`/`disable_suppression`, and the Stata `suppress` option still work as aliases, so existing scripts don't break. New helpers `enable_rounding(base=...)` / `disable_rounding()` mirror the suppression pair.

`margins=True` is rejected under rounding - rounded inner cells don't add up to rounded totals and that's a known attack vector (per the bounds-tightening discussion on #126). SDC audit records keep the raw disclosure-check results so rounding can't mask threshold failures.

If needed we can switch `margins=True` from hard-fail to warn-and-strip if thats better user experience. Left `StrEnum` for a follow up!

Closes #126.