### PR TITLE
feat(hist): flag bin-edge disclosure risks (#192)

### DIFF
--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -711,42 +711,51 @@ class Tables:
             )
             return None
 
-        freq, _ = np.histogram(
-            data[column], bins, range=(data[column].min(), data[column].max())
+        col_series = data[column].dropna()
+        if col_series.empty:  # pragma: no cover
+            logger.warning("Column %s is empty after dropping NaN.", column)
+            self.results.add(
+                status="fail",
+                output_type="histogram",
+                properties={"method": "histogram"},
+                sdc={},
+                command=command,
+                summary="fail; empty column after dropping NaN",
+                outcome=pd.DataFrame(),
+                output=[],
+            )
+            return None
+
+        col_min = float(col_series.min())
+        col_max = float(col_series.max())
+        masks, bin_edges, freq, left_count, right_count = _build_histogram_masks(
+            col_series, bins, col_min, col_max
         )
+        by_val, mismatch, sub_stats = _analyse_by_val_ranges(data, column, by_val)
 
-        # threshold check
-        threshold_mask = freq < THRESHOLD
+        sdc = get_histogram_sdc(
+            masks,
+            self.suppress,
+            bin_edges,
+            freq,
+            col_min,
+            col_max,
+            left_count,
+            right_count,
+            mismatch,
+            sub_stats,
+        )
+        status, summary = get_histogram_summary(sdc, column, col_min, col_max)
+        outcome = build_histogram_outcome(bin_edges, freq, masks)
+        logger.info("status: %s", status)
 
-        # plot the histogram
-        if np.any(threshold_mask):  # the column is disclosive
-            status = "fail"
-            if self.suppress:
-                logger.warning(
-                    "Histogram will not be shown as the %s column is disclosive.",
-                    column,
-                )
-            else:  # pragma: no cover
-                data.hist(
-                    column=column,
-                    by=by_val,
-                    grid=grid,
-                    xlabelsize=xlabelsize,
-                    xrot=xrot,
-                    ylabelsize=ylabelsize,
-                    yrot=yrot,
-                    ax=axis,
-                    sharex=sharex,
-                    sharey=sharey,
-                    figsize=figsize,
-                    layout=layout,
-                    bins=bins,
-                    backend=backend,
-                    legend=legend,
-                    **kwargs,
-                )
-        else:
-            status = "review"
+        # plot the histogram (skip when suppressed and disclosive)
+        if status == "fail" and self.suppress:
+            logger.warning(
+                "Histogram will not be shown as the %s column is disclosive.",
+                column,
+            )
+        else:  # pragma: no cover
             data.hist(
                 column=column,
                 by=by_val,
@@ -765,16 +774,6 @@ class Tables:
                 legend=legend,
                 **kwargs,
             )
-        logger.info("status: %s", status)
-
-        # create the summary
-        min_value = data[column].min()
-        max_value = data[column].max()
-        summary = (
-            f"Please check the minimum and the maximum values. "
-            f"The minimum value of the {column} column is: {min_value}. "
-            f"The maximum value of the {column} column is: {max_value}"
-        )
 
         # create the acro_artifacts directory to save the plot in it
         try:
@@ -803,10 +802,10 @@ class Tables:
             status=status,
             output_type="histogram",
             properties={"method": "histogram"},
-            sdc={},
+            sdc=sdc,
             command=command,
             summary=summary,
-            outcome=pd.DataFrame(),
+            outcome=outcome,
             output=[os.path.normpath(unique_filename)],
         )
         return unique_filename
@@ -1561,6 +1560,162 @@ def get_summary(sdc: dict[str, Any]) -> tuple[str, str]:
         summary = status
     logger.info("get_summary(): %s", summary)
     return status, summary
+
+
+def _python_scalar(value: Any) -> Any:
+    """Cast a numpy scalar to its Python equivalent for JSON serialisation."""
+    return value.item() if hasattr(value, "item") else value
+
+
+def _build_histogram_masks(
+    col_series: Series,
+    bins: int | Any,
+    col_min: float,
+    col_max: float,
+) -> tuple[dict[str, np.ndarray], np.ndarray, np.ndarray, int, int]:
+    """Compute histogram frequencies, edges, and the three per-bin risk masks."""
+    if isinstance(bins, int):
+        freq, bin_edges = np.histogram(col_series, bins, range=(col_min, col_max))
+    else:
+        freq, bin_edges = np.histogram(col_series, bins)
+
+    masks: dict[str, np.ndarray] = {"threshold": freq < THRESHOLD}
+
+    edge_mask = np.zeros_like(freq, dtype=bool)
+    edge_mask[0] = freq[0] < THRESHOLD
+    edge_mask[-1] = freq[-1] < THRESHOLD
+    masks["edge-bin"] = edge_mask
+
+    left_count = int((col_series == col_min).sum())
+    right_count = int((col_series == col_max).sum())
+    leak_mask = np.zeros_like(freq, dtype=bool)
+    if bin_edges[0] == col_min and left_count < THRESHOLD:
+        leak_mask[0] = True
+    if bin_edges[-1] == col_max and right_count < THRESHOLD:
+        leak_mask[-1] = True
+    masks["extreme-value-leak"] = leak_mask
+
+    return masks, bin_edges, freq, left_count, right_count
+
+
+def _analyse_by_val_ranges(
+    data: DataFrame, column: str, by_val: Any
+) -> tuple[Any, bool, DataFrame | None]:
+    """Compute per-subgroup min/max/count and whether ranges disagree."""
+    if by_val is None:
+        return by_val, False, None
+    if isinstance(by_val, pd.Series) and by_val.name is None:
+        by_val = by_val.rename("by_val")
+    sub_stats = (
+        data.groupby(by_val)[column]
+        .agg(["min", "max", "count"])
+        .dropna(subset=["min", "max"])
+    )
+    mismatch = bool(sub_stats["min"].nunique() > 1 or sub_stats["max"].nunique() > 1)
+    return by_val, mismatch, sub_stats
+
+
+def get_histogram_sdc(
+    masks: dict[str, np.ndarray],
+    suppress: bool,
+    bin_edges: np.ndarray,
+    freq: np.ndarray,
+    col_min: float,
+    col_max: float,
+    left_count: int,
+    right_count: int,
+    mismatch: bool,
+    sub_stats: DataFrame | None,
+) -> dict[str, Any]:
+    """Build the SDC dict for a histogram output.
+
+    When ``by_val`` is set, ``bin_edges``, ``counts``, and bin-indexed masks
+    describe the pooled aggregate across all subgroups; per-subgroup leak is
+    captured in ``by-val-range-mismatch`` and ``by_val_detail``.
+    """
+    sdc: dict[str, Any] = {
+        "summary": {
+            "suppressed": bool(suppress),
+            "threshold": int(masks["threshold"].sum()),
+            "edge-bin": int(masks["edge-bin"].sum()),
+            "extreme-value-leak": int(masks["extreme-value-leak"].sum()),
+            "by-val-range-mismatch": bool(mismatch),
+        },
+        "bins": {
+            "threshold": [int(i) for i in np.where(masks["threshold"])[0]],
+            "edge-bin": [int(i) for i in np.where(masks["edge-bin"])[0]],
+            "extreme-value-leak": [
+                int(i) for i in np.where(masks["extreme-value-leak"])[0]
+            ],
+        },
+        "bin_edges": [float(e) for e in bin_edges],
+        "counts": [int(c) for c in freq],
+        "column_min": float(col_min),
+        "column_max": float(col_max),
+        "min_count": int(left_count),
+        "max_count": int(right_count),
+        "by_val_detail": {},
+    }
+    if sub_stats is not None and not sub_stats.empty:
+        raw = sub_stats.reset_index().to_dict(orient="list")
+        sdc["by_val_detail"] = {
+            str(key): [_python_scalar(v) for v in values] for key, values in raw.items()
+        }
+    return sdc
+
+
+def get_histogram_summary(
+    sdc: dict[str, Any], column: str, col_min: float, col_max: float
+) -> tuple[str, str]:
+    """Return status and summary for a histogram's SDC dict."""
+    status = "review"
+    summary = ""
+    s = sdc["summary"]
+    sup = "suppressed" if s["suppressed"] else "may need suppressing"
+
+    if s["edge-bin"] > 0:
+        summary += f"edge-bin: {s['edge-bin']} edge bin(s) below threshold {sup}; "
+        status = "fail"
+    if s["threshold"] > 0:
+        summary += f"threshold: {s['threshold']} bins {sup}; "
+        status = "fail"
+    if s["extreme-value-leak"] > 0:
+        summary += (
+            f"extreme-value-leak: {s['extreme-value-leak']} edge(s) reveal exact "
+            f"min/max (min count={sdc['min_count']}, max count={sdc['max_count']}); "
+        )
+        status = "fail"
+    if s["by-val-range-mismatch"]:
+        summary += (
+            "by-val-range-mismatch: subgroup x-ranges differ "
+            "(aggregate counts shown; per-subgroup ranges in by_val_detail); "
+        )
+        status = "fail"
+
+    summary += f"min={col_min}, max={col_max} for column {column}"
+    summary = f"{status}; {summary}"
+    logger.info("get_histogram_summary(): %s", summary)
+    return status, summary
+
+
+def build_histogram_outcome(
+    bin_edges: np.ndarray, freq: np.ndarray, masks: dict[str, np.ndarray]
+) -> DataFrame:
+    """Return a per-bin outcome DataFrame labelling each bin with the checks it failed."""
+    order = ["threshold", "edge-bin", "extreme-value-leak"]
+    rows = []
+    for i, count in enumerate(freq):
+        failed = [name for name in order if masks[name][i]]
+        rows.append(
+            {
+                "bin_index": int(i),
+                "bin_left": float(bin_edges[i]),
+                "bin_right": float(bin_edges[i + 1]),
+                "count": int(count),
+                "checks_failed": "; ".join(failed) if failed else "ok",
+            }
+        )
+    return DataFrame(rows)
 
 
 def add_backticks(name: str) -> str:

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1220,7 +1220,7 @@ def test_histogram_explicit_bins_no_leak():
 
 
 def test_histogram_nan_handling():
-    """NaNs are dropped before SDC math; all-NaN column returns None."""
+    """Drop NaNs before SDC math; all-NaN column returns None."""
     shutil.rmtree("acro_artifacts", ignore_errors=True)
     shutil.rmtree(PATH, ignore_errors=True)
     np.random.seed(5)
@@ -1230,6 +1230,24 @@ def test_histogram_nan_handling():
     _ = a.hist(df, "val", bins=5)
     output = a.results.get_index(0)
     assert sum(output.sdc["counts"]) == 15
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+
+
+def test_histogram_by_val_unnamed_series():
+    """Accept an unnamed pd.Series as by_val without breaking by_val_detail keys."""
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+    shutil.rmtree(PATH, ignore_errors=True)
+    np.random.seed(6)
+    wages = np.concatenate(
+        [np.random.uniform(5.0, 10.0, size=30), np.random.uniform(4.0, 10.0, size=30)]
+    )
+    df = pd.DataFrame({"wage": wages})
+    grouper = pd.Series(["M"] * 30 + ["F"] * 30)  # no .name set
+    a = ACRO(suppress=False)
+    _ = a.hist(df, "wage", by_val=grouper, bins=6)
+    output = a.results.get_index(0)
+    assert "by_val" in output.sdc["by_val_detail"]
+    assert set(output.sdc["by_val_detail"]["by_val"]) == {"M", "F"}
     shutil.rmtree("acro_artifacts", ignore_errors=True)
 
 

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -1093,7 +1093,11 @@ def test_histogram_disclosive(data, acro, caplog):
 def test_histogram_non_disclosive(data, acro):
     """Test a non disclosive histogram."""
     filename = os.path.normpath("acro_artifacts/histogram_0.png")
-    _ = acro.hist(data, "inc_grants", bins=1)
+    # Bracket explicit bin edges outside the data extremes so extreme-value-leak
+    # cannot fire on the real-world min/max of inc_grants.
+    low = float(data["inc_grants"].min()) - 1.0
+    high = float(data["inc_grants"].max()) + 1.0
+    _ = acro.hist(data, "inc_grants", bins=[low, high])
     assert os.path.exists(filename)
     acro.add_exception("output_0", "Let me have it")
     results: Records = acro.finalise(path=PATH)
@@ -1101,6 +1105,146 @@ def test_histogram_non_disclosive(data, acro):
     assert output_0.output == [filename]
     assert output_0.status == "review"
     shutil.rmtree(PATH)
+
+
+def _make_wage_df(extra_low_count: int = 0) -> pd.DataFrame:
+    """Build a synthetic wage DataFrame with controllable low-end mass."""
+    np.random.seed(0)
+    low = np.random.uniform(0.0, 10.0, size=extra_low_count) if extra_low_count else []
+    mid = np.random.uniform(10.0, 90.0, size=10)
+    high = np.random.uniform(90.0, 100.0, size=15)
+    return pd.DataFrame({"wage": np.concatenate([low, mid, high])})
+
+
+def test_histogram_interior_threshold_only():
+    """Interior bins fail threshold but edge bins meet it."""
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+    shutil.rmtree(PATH, ignore_errors=True)
+    np.random.seed(0)
+    low = np.random.uniform(0.0, 10.0, size=15)
+    high = np.random.uniform(90.0, 100.0, size=15)
+    interior = np.linspace(15.0, 85.0, 10)
+    df = pd.DataFrame({"val": np.concatenate([low, interior, high])})
+    a = ACRO(suppress=False)
+    _ = a.hist(df, "val", bins=10)
+    output = a.results.get_index(0)
+    assert output.status == "fail"
+    assert output.sdc["summary"]["edge-bin"] == 0
+    assert output.sdc["summary"]["threshold"] > 0
+    assert "edge-bin" not in output.summary
+    assert "threshold:" in output.summary
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+
+
+def test_histogram_edge_bin_only():
+    """First bin falls below threshold; interior + last bins pass."""
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+    shutil.rmtree(PATH, ignore_errors=True)
+    # First bin [0,10): 5 rows. Bins 1..9 each get 10 rows evenly.
+    low = np.linspace(1.0, 9.0, 5)
+    interior = np.repeat(np.arange(15.0, 100.0, 10.0), 10)
+    df = pd.DataFrame({"val": np.concatenate([low, interior])})
+    a = ACRO(suppress=False)
+    _ = a.hist(df, "val", bins=10)
+    output = a.results.get_index(0)
+    assert output.status == "fail"
+    assert output.sdc["summary"]["edge-bin"] == 1
+    assert output.sdc["bins"]["edge-bin"] == [0]
+    assert "edge-bin:" in output.summary
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+
+
+def test_histogram_by_val_range_mismatch():
+    """Stratified histogram where subgroups have different ranges."""
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+    shutil.rmtree(PATH, ignore_errors=True)
+    np.random.seed(2)
+    male_wages = np.random.uniform(5.0, 10.0, size=30)
+    female_wages = np.random.uniform(4.0, 10.0, size=30)
+    df = pd.DataFrame(
+        {
+            "sex": ["M"] * 30 + ["F"] * 30,
+            "wage": np.concatenate([male_wages, female_wages]),
+        }
+    )
+    a = ACRO(suppress=False)
+    _ = a.hist(df, "wage", by_val="sex", bins=6)
+    output = a.results.get_index(0)
+    assert output.status == "fail"
+    assert output.sdc["summary"]["by-val-range-mismatch"] is True
+    assert "by-val-range-mismatch:" in output.summary
+    assert "sex" in output.sdc["by_val_detail"]
+    assert set(output.sdc["by_val_detail"]["sex"]) == {"M", "F"}
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+
+
+def test_histogram_extreme_value_leak():
+    """A single individual holds the minimum; leftmost edge reveals them."""
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+    shutil.rmtree(PATH, ignore_errors=True)
+    np.random.seed(3)
+    rest = np.random.uniform(5.0, 10.0, size=50)
+    df = pd.DataFrame({"wage": np.concatenate([[1.0], rest])})
+    a = ACRO(suppress=False)
+    _ = a.hist(df, "wage", bins=10)
+    output = a.results.get_index(0)
+    assert output.status == "fail"
+    assert output.sdc["summary"]["extreme-value-leak"] >= 1
+    assert output.sdc["min_count"] == 1
+    assert "extreme-value-leak:" in output.summary
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+
+
+def test_histogram_explicit_bins_no_leak():
+    """User-supplied bin edges that don't coincide with data extremes don't leak."""
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+    shutil.rmtree(PATH, ignore_errors=True)
+    # Data in [4.5, 10]; bin edges [4, 6, 8, 10.5] bracket away from the extremes.
+    # Each bin gets at least 10 rows.
+    values = np.concatenate(
+        [
+            np.linspace(4.5, 5.9, 10),
+            np.linspace(6.0, 7.9, 15),
+            np.linspace(8.0, 10.0, 12),
+        ]
+    )
+    df = pd.DataFrame({"val": values})
+    a = ACRO(suppress=False)
+    _ = a.hist(df, "val", bins=[4.0, 6.0, 8.0, 10.5])
+    output = a.results.get_index(0)
+    assert output.status == "review"
+    assert output.sdc["summary"]["extreme-value-leak"] == 0
+    assert output.sdc["summary"]["edge-bin"] == 0
+    assert output.sdc["summary"]["threshold"] == 0
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+
+
+def test_histogram_nan_handling():
+    """NaNs are dropped before SDC math; all-NaN column returns None."""
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+    shutil.rmtree(PATH, ignore_errors=True)
+    np.random.seed(5)
+    valid = np.random.uniform(0.0, 100.0, size=15)
+    df = pd.DataFrame({"val": np.concatenate([valid, [np.nan] * 5])})
+    a = ACRO(suppress=False)
+    _ = a.hist(df, "val", bins=5)
+    output = a.results.get_index(0)
+    assert sum(output.sdc["counts"]) == 15
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+
+
+def test_histogram_integer_column_extreme_leak():
+    """Integer-valued column with a single maximum trips extreme-value-leak."""
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
+    shutil.rmtree(PATH, ignore_errors=True)
+    df = pd.DataFrame({"age": [20] * 30 + [65]})
+    a = ACRO(suppress=False)
+    _ = a.hist(df, "age", bins=10)
+    output = a.results.get_index(0)
+    assert output.status == "fail"
+    assert output.sdc["summary"]["extreme-value-leak"] >= 1
+    assert output.sdc["max_count"] == 1
+    shutil.rmtree("acro_artifacts", ignore_errors=True)
 
 
 def test_pie_disclosive(acro, caplog):


### PR DESCRIPTION
Closes #192.

Histograms previously only checked interior bins against the frequency threshold and returned empty sdc / outcome results. This PR adds three more leakage checks and populates the outputs:

edge-bin - first or last bin holds fewer than THRESHOLD rows.
extreme-value-leak - a bin edge sits exactly on the column min/max with fewer than THRESHOLD rows at that value.
by-val-range-mismatch - when by_val is set, subgroups with differing min/max leak per-subgroup ranges through the x-axis even though the pooled histogram looks safe.

Any of these (or the original interior check) flips status to fail. sdc now carries bin edges, counts, the failing bin indices and per-subgroup detail; outcome is a per-bin DataFrame instead of empty. NaNs are dropped before counting; an all-NaN column short-circuits to fail rather than raising.

Let me know if you think this approach is the way envisioned or some changes to adjust :)