### PR TITLE
fix: include custom outputs in xlsx finalisation

### DIFF
--- a/acro/record.py
+++ b/acro/record.py
@@ -516,11 +516,11 @@ class Records:
             summary: list[str] = []
             command: list[str] = []
             for output_id, output in self.results.items():
-                if output.output_type == "custom":
-                    continue  # avoid writing custom outputs
                 sheet.append(output_id)
                 command.append(output.command)
                 summary.append(output.summary)
+                if output.output_type == "custom":
+                    output.serialize_output(path)
             tmp_df = pd.DataFrame(
                 {"Sheet": sheet, "Command": command, "Summary": summary}
             )
@@ -528,7 +528,7 @@ class Records:
             # individual sheets
             for output_id, output in self.results.items():
                 if output.output_type == "custom":
-                    continue  # avoid writing custom outputs
+                    continue  # custom files are copied and listed in the description sheet
                 # command and summary
                 start = 0
                 tmp_df = pd.DataFrame(

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -352,7 +352,7 @@ def test_finalise_excel(data, acro):
     """Finalise excel test."""
     _ = acro.crosstab(data.year, data.grant_type)
     acro.add_exception("output_0", "Let me have it")
-    with open("foo.txt", "w") as file:
+    with open("foo.txt", "w", encoding="utf-8") as file:
         file.write("Your text goes here")
     acro.custom_output("foo.txt")
 
@@ -360,10 +360,16 @@ def test_finalise_excel(data, acro):
     output_0 = results.get_index(0)
     filename = os.path.normpath(f"{PATH}/results.xlsx")
     load_data = pd.read_excel(filename, sheet_name=output_0.uid)
+    description = pd.read_excel(filename, sheet_name="description")
     correct_cell: str = "_ = acro.crosstab(data.year, data.grant_type)"
     assert load_data.iloc[0, 0] == "Command"
     assert load_data.iloc[0, 1] == correct_cell
+    assert os.path.exists(os.path.normpath(f"{PATH}/foo.txt"))
+    assert "output_1" in description["Sheet"].values
+    assert "custom" in description["Command"].values
+    assert "review" in description["Summary"].values
     shutil.rmtree(PATH)
+    os.remove("foo.txt")
 
 
 def test_output_removal(data, acro, monkeypatch):


### PR DESCRIPTION
Fixes #312.

This PR updates XLSX finalisation so custom outputs are copied into the output folder and listed in the generated description sheet, matching the behavior of JSON finalisation.

QA:
- Reproduced the bug locally before the fix: JSON copied the custom output, while XLSX created results.xlsx but did not copy or list the custom output.
- Confirmed the same reproduction case passes after the fix.
- Added regression coverage to test_finalise_excel.
- Ran pytest: 128 passed.
- Ran prek run -a: all checks passed.