### PR TITLE
feat: honor zeros_are_disclosive in hist() empty bin check (#308)

### DIFF
--- a/acro/acro_tables.py
+++ b/acro/acro_tables.py
@@ -853,6 +853,13 @@ class Tables:
             The histogram.
         str
             The name of the file where the histogram is saved.
+
+        Notes
+        -----
+        When ``zeros_are_disclosive`` is set to ``False`` in the config, empty
+        bins (count == 0) are excluded from the disclosure threshold check.
+        This avoids flagging histograms as disclosive solely because outliers
+        in a wide-spread column produced empty tail bins.
         """
         logger.debug("hist()")
         if utils.is_blocked_extension(filename, self.results.blocked_extensions):
@@ -870,8 +877,16 @@ class Tables:
             data[column], bins, range=(data[column].min(), data[column].max())
         )
 
-        # threshold check
+        # threshold check; empty bins are excluded when zeros_are_disclosive is False
         threshold_mask = freq < THRESHOLD
+        if not ZEROS_ARE_DISCLOSIVE:
+            empty_bins = freq == 0
+            threshold_mask &= ~empty_bins
+            if np.any(empty_bins):
+                logger.debug(
+                    "%d empty bin(s) excluded from threshold check",
+                    int(np.sum(empty_bins)),
+                )
 
         # plot the histogram
         if np.any(threshold_mask):  # the column is disclosive

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -72,7 +72,7 @@ TRE Risk Appetite Settings
    Minimum observations for survival analysis outputs
 
 **zeros_are_disclosive** (default: true)
-   Whether zero values are considered disclosive. TREs can set this to false for datasets where class disclosure is not relevant
+   Whether zero values are considered disclosive. TREs can set this to false for datasets where class disclosure is not relevant. Also controls whether empty bins (count == 0) are excluded from the disclosure threshold check in ``hist()``.
 
 Behavioral Settings
 -------------------

--- a/test/test_initial.py
+++ b/test/test_initial.py
@@ -6,6 +6,10 @@ import os
 import shutil
 from unittest.mock import patch
 
+import matplotlib as mpl
+
+mpl.use("Agg")
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -1157,6 +1161,59 @@ def test_histogram_non_disclosive(data, acro):
     output_0 = results.get_index(0)
     assert output_0.output == [filename]
     assert output_0.status == "review"
+    shutil.rmtree(PATH)
+
+
+def test_histogram_zeros_not_disclosive(acro):
+    """Empty tail bins do not flag a histogram when zeros_are_disclosive=False."""
+    filename = os.path.normpath(f"{ARTIFACTS_DIR}/histogram_0.png")
+    # 100 obs at each of 6 distinct values spanning [0, 10]; with bins=20, the
+    # only sub-threshold bins are the empty ones between the populated values.
+    df = pd.DataFrame({"x": np.repeat([0.0, 1.0, 2.0, 3.0, 5.0, 10.0], 100)})
+    acro_tables.ZEROS_ARE_DISCLOSIVE = False
+    try:
+        _ = acro.hist(df, "x", bins=20)
+    finally:
+        acro_tables.ZEROS_ARE_DISCLOSIVE = True
+    assert os.path.exists(filename)
+    acro.add_exception("output_0", "Let me have it")
+    results: Records = acro.finalise(path=PATH)
+    output_0 = results.get_index(0)
+    assert output_0.output == [filename]
+    assert output_0.status == "review"
+    shutil.rmtree(PATH)
+
+
+def test_histogram_zeros_disclosive_default(acro, caplog):
+    """Empty bins remain disclosive under the default zeros_are_disclosive=True."""
+    filename = os.path.normpath(f"{ARTIFACTS_DIR}/histogram_0.png")
+    df = pd.DataFrame({"x": np.repeat([0.0, 1.0, 2.0, 3.0, 5.0, 10.0], 100)})
+    _ = acro.hist(df, "x", bins=20)
+    assert os.path.exists(filename)
+    acro.add_exception("output_0", "Let me have it")
+    results: Records = acro.finalise(path=PATH)
+    output_0 = results.get_index(0)
+    assert output_0.output == [filename]
+    assert output_0.status == "fail"
+    assert "Histogram will not be shown as the x column is disclosive." in caplog.text
+    shutil.rmtree(PATH)
+
+
+def test_histogram_nonempty_below_threshold_still_disclosive(acro):
+    """A non-empty bin below threshold remains disclosive even when zeros are not."""
+    filename = os.path.normpath(f"{ARTIFACTS_DIR}/histogram_0.png")
+    # bins=2 over [0, 5]: one bin has 100 obs, the other has 5 (non-empty, < THRESHOLD).
+    df = pd.DataFrame({"x": np.r_[np.repeat(0.0, 100), np.repeat(5.0, 5)]})
+    acro_tables.ZEROS_ARE_DISCLOSIVE = False
+    try:
+        _ = acro.hist(df, "x", bins=2)
+    finally:
+        acro_tables.ZEROS_ARE_DISCLOSIVE = True
+    assert os.path.exists(filename)
+    acro.add_exception("output_0", "Let me have it")
+    results: Records = acro.finalise(path=PATH)
+    output_0 = results.get_index(0)
+    assert output_0.status == "fail"
     shutil.rmtree(PATH)
 
 


### PR DESCRIPTION
closes #308

## summary

when calling hist() on a numeric column with wide spread or outliers, np.histogram splits the range into equal-width bins which almost always leaves at least one empty bin at the tails. acro's threshold check (freq < threshold) treats those empty bins as disclosive since 0 is below threshold, so the histogram is marked "fail" and under suppress=true is never displayed. this makes informative histograms (bins=20 or higher) effectively unusable on real-world data unless the user manually crafts bin edges or drops safe_threshold to 0.

acro already has a `zeros_are_disclosive` flag in default.yaml for exactly this kind of decision, but it was not being consulted by hist(). it was only used by agg_p_percent for the p-ratio rule on crosstab and pivot_table.

## changes

- hist() now reads the `zeros_are_disclosive` flag. when it is false, empty bins (count == 0) are excluded from the disclosure threshold mask. populated bins below threshold are still flagged as before.
- defult behaviour (flag true) is byte-identical to today, so existing pipelines are not affected.
- updated the hist() docstring with a short notes section explaining the interaction.
- extended the configuration.rst entry for `zeros_are_disclosive` to mention that it now also controls empty-bin handling in hist().

## tests

added three tests in test/test_initial.py:

- `test_histogram_zeros_not_disclosive`: with the flag off, a histogram on a column where the only sub-threshold bins are empty should pass with status "review". this is the acceptence test for the issue.
- `test_histogram_zeros_disclosive_default`: with the default (flag on), the same input must still fail. regression guard for default behaviour.
- `test_histogram_nonempty_below_threshold_still_disclosive`: with the flag off, a non-empty bin with count below threshold is still flagged. confirms we did not over-relax the rule.

all three new tests restore the global in a `finally` block so they do not bleed state into other tests. the existing `test_histogram_disclosive` and `test_histogram_non_disclosive` are unchanged and still pass.

## note for reviewers

added `import matplotlib as mpl` followed by `mpl.use("Agg")` at the top of test/test_initial.py. the new histogram tests use synthetic dataframes which trigger pandas' plotting path more aggressively than the existing two histogram tests; without pinning to the agg backend, ci or local runs without a display can hit a tkinter init error. the existing histogram tests happened to slip through this but it was a latent flake.