### PR TITLE
Fix: join index conditions with & to avoid TypeError

### DIFF
--- a/acro/table_utils.py
+++ b/acro/table_utils.py
@@ -606,7 +606,7 @@ def _get_cell_query(
 
     parts.extend(_format_label_condition(index_level_names, row_label))
     if len(column_level_names) == 1 and column_level_names[0] is None:
-        joined = "".join(parts)
+        joined = " & ".join(parts)
         logger.debug("joined is %s", joined)
         return joined
     parts.extend(_format_label_condition(column_level_names, col_label))

--- a/test/test_table_utils.py
+++ b/test/test_table_utils.py
@@ -919,7 +919,23 @@ class TestGetRedactedData:
             f"\ngot\n{redacted_table.values}\nexpected\n{pandas_redacted_pivot.values}"
             f"types of columns are\n{unsafedata['over30'].dtype}\n{safedata['over30'].dtype}"
         )
-        # assert False, (
-        #     f"\ngot\n{redacted_table.values}\nexpected\n{pandas_redacted_pivot.values}"
-        #     f"types of columns are\n{unsafedata['over30'].dtype}\n{safedata['over30'].dtype}"
-        # )
+
+    def test_get_redacted_pivottable_multi_index_no_columns(self):
+        """Test that query generation works correctly with multi-index and no column dimensions."""
+        df = pd.DataFrame(
+            {
+                "parents": ["usual", "usual", "pretentious", "pretentious"],
+                "recommend": ["not_recom", "recommend", "not_recom", "recommend"],
+                "children": [1, 2, 1, 2],
+            }
+        )
+        ac = ACRO()
+        ac.enable_suppression()
+        result = ac.pivot_table(
+            data=df,
+            index=["parents", "recommend"],
+            values="children",
+            aggfunc=["mean"],
+        )
+        assert result is not None
+        assert isinstance(result, pd.DataFrame)

--- a/test/test_table_utils.py
+++ b/test/test_table_utils.py
@@ -937,5 +937,33 @@ class TestGetRedactedData:
             values="children",
             aggfunc=["mean"],
         )
+
         assert result is not None
         assert isinstance(result, pd.DataFrame)
+
+        assert result.isna().all().all(), (
+            f"Expected all values to be NaN due to suppression, got:\n{result}"
+        )
+
+        df_extended = pd.DataFrame(
+            {
+                "parents": ["usual"] * 12 + ["pretentious"] * 2,
+                "recommend": ["recommend"] * 12 + ["not_recom", "recommend"],
+                "children": [3] * 12 + [1, 2],
+            }
+        )
+        ac2 = ACRO()
+        ac2.enable_suppression()
+        result2 = ac2.pivot_table(
+            data=df_extended,
+            index=["parents", "recommend"],
+            values="children",
+            aggfunc=["mean"],
+        )
+
+        assert result2 is not None
+        values = result2.values.flatten()
+        preserved_cells = ~pd.isna(values)
+        assert preserved_cells.sum() > 0, (
+            f"Expected at least one cell to be preserved, got:\n{result2}"
+        )


### PR DESCRIPTION
When suppression is enabled on a ⁠ pivot_table ⁠ with multiple index variables and no column variables (e.g. ⁠ index=["parents", "recommend"] ⁠, ⁠ columns=None ⁠), ⁠ get_redacted_data ⁠ fails with ⁠ TypeError: Only named functions are supported ⁠ when executing ⁠ redacted_data.query(f"not ({query})") ⁠.
### Root Cause
In ⁠ acro/table_utils.py ⁠ inside ⁠ _get_cell_query() ⁠:
```python
parts.extend(_format_label_condition(index_level_names, row_label))
if len(column_level_names) == 1 and column_level_names[0] is None:
    joined = "".join(parts)
    logger.debug("joined is %s", joined)
    return joined
When there are multiple row indices, parts contains a list of conditions like ['(parents == "usual")', '(recommend == "not_recom")']. Because "".join(parts) joins the conditions without a boolean operator, the query string becomes:


(parents == "usual")(recommend == "not_recom")
When evaluated by pandas' AST query parser, adjacent bracketed expressions are parsed as function call invocations Call(func=..., args=...), triggering pandas' validation error:

TypeError: Only named functions are supported
Proposed Fix
Join the condition parts with " & " instead:

if len(column_level_names) == 1 and column_level_names[0] is None:
    joined = " & ".join(parts)
    logger.debug("joined is %s", joined)
    return joined
Steps to Reproduce


import pandas as pd
from acro import ACRO
df = pd.DataFrame({
    "parents": ["usual", "usual", "pretentious", "pretentious"],
    "recommend": ["not_recom", "recommend", "not_recom", "recommend"],
    "children": [1, 2, 1, 2],
})
ac = ACRO()
ac.enable_suppression()
res = ac.pivot_table(df, index=["parents", "recommend"], values="children", aggfunc=["mean"])
